### PR TITLE
ucache: New flat (simple) Cache

### DIFF
--- a/ucache/multicache.go
+++ b/ucache/multicache.go
@@ -1,0 +1,566 @@
+package ucache
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"sync"
+	"time"
+
+	"github.com/dgryski/go-farm"
+	"github.com/kordax/basic-utils/uarray"
+	"github.com/kordax/basic-utils/uopt"
+)
+
+type container[K CompositeKey, T Comparable] struct {
+	pairs map[int64][]uarray.Pair[K, T]
+	node  map[int64]any
+}
+
+type MultiCache[K CompositeKey, T Comparable] interface {
+	// Put inserts a new value(s) into the cache associated with the given key.
+	// If the key already exists in the cache, it appends the new value(s) to the existing values.
+	// This operation is relatively fast for shallow depth keys, but becomes slower as the depth increases.
+	Put(key K, values ...T)
+
+	// Set inserts a new value(s) into the cache associated with the given key.
+	// If the key already exists in the cache, this method will overwrite the existing values.
+	Set(key K, values ...T)
+
+	// Get retrieves the value(s) associated with the given key from the cache.
+	// If the key is not found, it returns an empty slice.
+	// Retrieval is fast, especially for shallow depth keys.
+	Get(key K) []T
+
+	// Changes returns a slice of keys that have been modified in the cache.
+	// This method provides a way to track changes made to the cache, useful for scenarios like cache syncing.
+	Changes() []K
+
+	// Drop removes all entries from the cache.
+	// This is a complete reset of the cache, useful when you want to clear the cache and start fresh.
+	Drop()
+
+	// DropKey removes the value(s) associated with the given key from the cache.
+	DropKey(key K)
+
+	// Outdated checks if a given key or the entire cache is outdated based on the TTL.
+	// If no key is provided or key was not found, it checks the last updated time of the entire cache.
+	// If a key is provided and found, it checks the last updated time of that specific key.
+	Outdated(key uopt.Opt[K]) bool
+
+	// PutQuietly behaves like the Put method but does not update the cache state or add any changes to the cache, making it
+	// much faster alternative to Put and Set.
+	// This method is useful when you want to add values to the cache without triggering any side effects.
+	PutQuietly(key K, values ...T)
+}
+
+// InMemoryTreeMultiCache provides an in-memory caching mechanism with support for compound keys.
+// The cache leverages tree-like structures to store and organize data, allowing efficient
+// operations even with composite keys. The cache supports optional TTL (time-to-live) for entries,
+// ensuring that outdated entries can be identified and potentially purged. Concurrency-safe
+// operations are ensured through the use of a mutex.
+//
+// Benchmark insights:
+// - Put operation performance is fast for shallow depth keys but slows down as the depth increases.
+// - Get operation is particularly efficient, especially for shallow depth keys.
+// - Set operation's performance is consistent regardless of the depth of the key.
+type InMemoryTreeMultiCache[K CompositeKey, T Comparable] struct {
+	values  map[int64]any
+	changes []K
+
+	lastUpdatedKeys map[string]time.Time
+	lastUpdated     time.Time
+	ttl             *time.Duration
+
+	vMtx sync.Mutex
+}
+
+// NewInMemoryTreeMultiCache creates a new instance of the InMemoryTreeMultiCache.
+// It takes an optional TTL (time-to-live) parameter to set expiration time for cache entries.
+// If the TTL is not provided, cache entries will not expire.
+func NewInMemoryTreeMultiCache[K CompositeKey, T Comparable](ttl uopt.Opt[time.Duration]) *InMemoryTreeMultiCache[K, T] {
+	c := &InMemoryTreeMultiCache[K, T]{
+		values:          make(map[int64]any),
+		changes:         make([]K, 0),
+		lastUpdatedKeys: make(map[string]time.Time),
+	}
+	ttl.IfPresent(func(t time.Duration) {
+		c.ttl = &t
+	})
+
+	return c
+}
+
+// Put inserts a new value(s) into the cache associated with the given key.
+// If the key already exists in the cache, it appends the new value(s) to the existing values.
+// This operation is relatively fast for shallow depth keys, but becomes slower as the depth increases.
+func (c *InMemoryTreeMultiCache[K, T]) Put(key K, val ...T) {
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+	c.put(key, val...)
+	c.lastUpdatedKeys[key.String()] = time.Now()
+	c.lastUpdated = time.Now()
+}
+
+// Set inserts a new value(s) into the cache associated with the given key.
+// If the key already exists in the cache, this method will overwrite the existing values.
+func (c *InMemoryTreeMultiCache[K, T]) Set(key K, val ...T) {
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+	c.dropKeyRecursively(key.Keys(), 0, c.values)
+	c.put(key, val...)
+	c.lastUpdatedKeys[key.String()] = time.Now()
+	c.lastUpdated = time.Now()
+}
+
+// PutQuietly behaves like the Put method but does not update the cache state or add any changes to the cache, making it
+// much faster alternative to Put and Set.
+// This method is useful when you want to add values to the cache without triggering any side effects.
+func (c *InMemoryTreeMultiCache[K, T]) PutQuietly(key K, val ...T) {
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+	c.addTran(key, val...)
+	c.lastUpdatedKeys[key.String()] = time.Now()
+	c.lastUpdated = time.Now()
+}
+
+// Get retrieves the value(s) associated with the given key from the cache.
+// If the key is not found, it returns an empty slice.
+// Retrieval is fast, especially for shallow depth keys.
+func (c *InMemoryTreeMultiCache[K, T]) Get(key K) []T {
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+	c.changes = nil
+	bucket := c.tryToGetBucket(key.Keys())
+	result := make([]T, 0)
+	for _, pairs := range bucket {
+		for _, p := range pairs {
+			result = append(result, p.Right)
+		}
+	}
+
+	return result
+}
+
+// Changes returns a slice of keys that have been modified in the cache.
+// This method provides a way to track changes made to the cache, useful for scenarios like cache syncing.
+func (c *InMemoryTreeMultiCache[K, T]) Changes() []K {
+	return c.changes
+}
+
+// Drop removes all entries from the cache.
+// This is a complete reset of the cache, useful when you want to clear the cache and start fresh.
+func (c *InMemoryTreeMultiCache[K, T]) Drop() {
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+	c.dropAll()
+	c.lastUpdatedKeys = make(map[string]time.Time)
+}
+
+// DropKey removes the value(s) associated with the given key from the cache.
+func (c *InMemoryTreeMultiCache[K, T]) DropKey(key K) {
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+	c.dropKeyRecursively(key.Keys(), 0, c.values)
+	c.lastUpdatedKeys[key.String()] = time.Now()
+	c.lastUpdated = time.Now()
+}
+
+// Outdated checks if a given key or the entire cache is outdated based on the TTL.
+// If no key is provided or key was not found, it checks the last updated time of the entire cache.
+// If a key is provided and found, it checks the last updated time of that specific key.
+func (c *InMemoryTreeMultiCache[K, T]) Outdated(key uopt.Opt[K]) bool {
+	if !key.Present() {
+		return time.Since(c.lastUpdated) > *c.ttl
+	}
+
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+
+	if c.ttl == nil {
+		return false
+	} else {
+		if key.Present() {
+			k := key.Get()
+			if lu, ok := c.lastUpdatedKeys[(*k).String()]; ok {
+				return time.Since(lu) > *c.ttl
+			} else {
+				return true
+			}
+		} else {
+			return time.Since(c.lastUpdated) > *c.ttl
+		}
+	}
+}
+
+func (c *InMemoryTreeMultiCache[K, T]) dropAll() {
+	c.values = make(map[int64]any)
+	c.changes = nil
+}
+
+func (c *InMemoryTreeMultiCache[K, T]) put(key K, val ...T) {
+	c.addTran(key, val...)
+	changes := len(c.changes) == 0
+	found := false
+	for _, diff := range c.changes {
+		if uarray.EqualsWithOrder(diff.Keys(), key.Keys()) {
+			if !diff.Equals(key) {
+				changes = true
+				break
+			}
+			found = true
+			continue
+		}
+	}
+	if changes || !found {
+		c.changes = append(c.changes, key)
+	}
+}
+
+func (c *InMemoryTreeMultiCache[K, T]) addTran(key K, values ...T) {
+	hashes := key.Keys()
+	if len(hashes) == 0 {
+		return
+	}
+
+	bucket := c.tryToGetBucket(hashes)
+	lHash := key.Keys()[len(hashes)-1]
+
+	for _, value := range values {
+		if ind, _ := uarray.ContainsPredicate(bucket[lHash], func(v *uarray.Pair[K, T]) bool {
+			return v.Right.Equals(value)
+		}); ind > -1 {
+			bucket[lHash][ind] = *uarray.NewPair[K, T](key, value)
+		} else {
+			bucket[lHash] = append(bucket[lHash], *uarray.NewPair[K, T](key, value))
+		}
+	}
+}
+
+func (c *InMemoryTreeMultiCache[K, T]) dropKeyRecursively(keys []int64, n int, bucket map[int64]any) {
+	hash := keys[n]
+	interBucket := bucket[hash]
+	if interBucket != nil {
+		switch b := interBucket.(type) {
+		case container[K, T]:
+			if n+1 == len(keys) {
+				delete(bucket, hash)
+			} else {
+				c.dropKeyRecursively(keys, n+1, b.node)
+			}
+		default:
+			delete(bucket, hash)
+		}
+	}
+}
+
+func (c *InMemoryTreeMultiCache[K, T]) tryToGetBucket(keys []int64) map[int64][]uarray.Pair[K, T] {
+	return c.getBucket(keys, 0, c.values)
+}
+
+func (c *InMemoryTreeMultiCache[K, T]) getBucket(keys []int64, n int, interBucket map[int64]any) map[int64][]uarray.Pair[K, T] {
+	if keys == nil || n >= len(keys) {
+		return nil
+	}
+
+	if bucket, ok := interBucket[keys[n]]; ok {
+		switch b := bucket.(type) {
+		case map[int64][]uarray.Pair[K, T]:
+			if n+1 < len(keys) {
+				interBucket[keys[n]] = container[K, T]{
+					node:  make(map[int64]any),
+					pairs: b,
+				}
+				return c.getBucket(keys, n+1, interBucket[keys[n]].(container[K, T]).node)
+			} else {
+				return b
+			}
+		case container[K, T]:
+			if n+1 == len(keys) {
+				result := make(map[int64][]uarray.Pair[K, T])
+				for k, e := range b.pairs {
+					result[k] = append(result[k], e...)
+				}
+				if b.node != nil {
+					result = c.getNodePairsFlat(b.node, result)
+				}
+
+				return result
+			}
+
+			return c.getBucket(keys, n+1, b.node)
+		}
+	} else {
+		if n+1 == len(keys) {
+			interBucket[keys[n]] = map[int64][]uarray.Pair[K, T]{
+				keys[n]: nil,
+			}
+			return interBucket[keys[n]].(map[int64][]uarray.Pair[K, T])
+		} else {
+			if entry, ok := interBucket[keys[n]]; !ok {
+				interBucket[keys[n]] = container[K, T]{
+					node:  make(map[int64]any),
+					pairs: make(map[int64][]uarray.Pair[K, T]),
+				}
+				return c.getBucket(keys, n+1, interBucket[keys[n]].(container[K, T]).node)
+			} else {
+				switch e := entry.(type) {
+				case map[int64][]uarray.Pair[K, T]:
+					interBucket[keys[n]] = container[K, T]{
+						node:  make(map[int64]any),
+						pairs: e,
+					}
+					return c.getBucket(keys, n+1, interBucket[keys[n]].(container[K, T]).node)
+				case container[K, T]:
+					interBucket[keys[n]] = container[K, T]{
+						pairs: e.pairs,
+					}
+					return c.getBucket(keys, n+1, e.node)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *InMemoryTreeMultiCache[K, T]) getNodePairsFlat(node map[int64]any, result map[int64][]uarray.Pair[K, T]) map[int64][]uarray.Pair[K, T] {
+	for _, entry := range node {
+		switch e := entry.(type) {
+		case map[int64][]uarray.Pair[K, T]:
+			for hash, pair := range e {
+				result[hash] = append(result[hash], pair...)
+			}
+		case container[K, T]:
+			for hash, pair := range e.pairs {
+				result[hash] = append(result[hash], pair...)
+			}
+			result = c.getNodePairsFlat(e.node, result)
+		}
+	}
+
+	return result
+}
+
+// InMemoryHashMapMultiCache provides an in-memory caching mechanism using hashmaps.
+// Unlike InMemoryHashMapCache, it stores multiple values per key.
+// This cache structure translates composite keys into a hash value using a user-provided
+// hashing function. The cache supports optional TTL (time-to-live) for entries.
+// Concurrency-safe operations are ensured through the use of a mutex.
+//
+// Performance Comparison with InMemoryTreeMultiCache:
+// - Insertions: InMemoryTreeMultiCache is slightly faster for single-depth insertions and significantly faster for deeper depths.
+// - Retrievals: InMemoryHashMapMultiCache (especially with FarmHash) is faster for both single-depth and deeper retrievals.
+// - Setting Values: Performance is relatively close between the two, with minor variations.
+//
+// The choice between InMemoryTreeMultiCache and InMemoryHashMapMultiCache would depend on the specific use case,
+// especially the depth of the keys and the frequency of retrieval operations.
+type InMemoryHashMapMultiCache[K CompositeKey, T Comparable, H comparable] struct {
+	values  map[H][]T
+	changes []K
+
+	lastUpdatedKeys map[string]time.Time
+	lastUpdated     time.Time
+	ttl             *time.Duration
+
+	toHash func(keys []int64) H
+	vMtx   sync.Mutex
+}
+
+// NewInMemoryHashMapMultiCache creates a new instance of the InMemoryHashMapMultiCache.
+// It takes a hashing function to translate the composite keys to a desired hash type,
+// and an optional time-to-live duration for the cache entries.
+func NewInMemoryHashMapMultiCache[K CompositeKey, T Comparable, H comparable](toHash func(keys []int64) H, ttl uopt.Opt[time.Duration]) *InMemoryHashMapMultiCache[K, T, H] {
+	c := &InMemoryHashMapMultiCache[K, T, H]{
+		values:          make(map[H][]T),
+		changes:         make([]K, 0),
+		lastUpdatedKeys: make(map[string]time.Time),
+		toHash:          toHash,
+	}
+	ttl.IfPresent(func(t time.Duration) {
+		c.ttl = &t
+	})
+
+	return c
+}
+
+// NewDefaultHashMapMultiCache creates a new instance of the InMemoryHashMapMultiCache using SHA256 as the hashing algorithm.
+func NewDefaultHashMapMultiCache[K CompositeKey, T Comparable](ttl uopt.Opt[time.Duration]) *InMemoryHashMapMultiCache[K, T, uint64] {
+	return NewFarmHashMapMultiCache[K, T](ttl)
+}
+
+func NewFarmHashMapMultiCache[K CompositeKey, T Comparable](ttl uopt.Opt[time.Duration]) *InMemoryHashMapMultiCache[K, T, uint64] {
+	buffer := new(bytes.Buffer)
+	return NewInMemoryHashMapMultiCache[K, T, uint64](func(keys []int64) uint64 {
+		arr := make([]byte, 0)
+		for _, hash := range keys {
+			arr = append(arr, intToBytes(buffer, hash)...)
+		}
+
+		return farm.Hash64(arr)
+	}, ttl)
+}
+
+func NewSha256HashMapMultiCache[K CompositeKey, T Comparable](ttl uopt.Opt[time.Duration]) *InMemoryHashMapMultiCache[K, T, string] {
+	buffer := new(bytes.Buffer)
+	return NewInMemoryHashMapMultiCache[K, T, string](func(keys []int64) string {
+		arr := make([]byte, 0)
+		for _, hash := range keys {
+			arr = append(arr, intToBytes(buffer, hash)...)
+		}
+
+		h := sha256.New()
+		h.Write(arr)
+
+		return string(h.Sum(nil))
+	}, ttl)
+}
+
+// Put adds the given values to the cache associated with the provided key.
+// If the key already exists, the values are updated. The insertion is thread-safe.
+func (c *InMemoryHashMapMultiCache[K, T, H]) Put(key K, values ...T) {
+	if len(values) == 0 {
+		return
+	}
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+	c.put(key, values...)
+	c.lastUpdatedKeys[key.String()] = time.Now()
+	c.lastUpdated = time.Now()
+}
+
+// Set updates the cache values for the provided key. If the key already exists,
+// its previous values are removed before adding the new values. The operation is thread-safe.
+func (c *InMemoryHashMapMultiCache[K, T, H]) Set(key K, values ...T) {
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+	c.dropKey(key.Keys())
+	c.put(key, values...)
+	c.lastUpdatedKeys[key.String()] = time.Now()
+	c.lastUpdated = time.Now()
+}
+
+// PutQuietly adds values to the cache for the provided key but does so without
+// altering the change history. This operation can be used when modifications should not trigger cache change diff.
+func (c *InMemoryHashMapMultiCache[K, T, H]) PutQuietly(key K, values ...T) {
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+	c.addTran(key, values...)
+	c.lastUpdatedKeys[key.String()] = time.Now()
+	c.lastUpdated = time.Now()
+}
+
+// Get retrieves the values associated with the provided key from the cache.
+// The operation is thread-safe and does not alter the change history.
+func (c *InMemoryHashMapMultiCache[K, T, H]) Get(key K) []T {
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+	c.changes = nil
+
+	return c.values[c.toHash(key.Keys())]
+}
+
+// Changes returns a list of keys that have experienced changes in the cache since the last reset.
+func (c *InMemoryHashMapMultiCache[K, T, H]) Changes() []K {
+	return c.changes
+}
+
+// Drop completely clears the cache, removing all entries. The operation is thread-safe.
+func (c *InMemoryHashMapMultiCache[K, T, H]) Drop() {
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+	c.dropAll()
+	c.lastUpdatedKeys = make(map[string]time.Time)
+}
+
+// DropKey removes the values associated with the provided key from the cache. The operation is thread-safe.
+func (c *InMemoryHashMapMultiCache[K, T, H]) DropKey(key K) {
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+	c.dropKey(key.Keys())
+	c.lastUpdatedKeys[key.String()] = time.Now()
+	c.lastUpdated = time.Now()
+}
+
+// Outdated checks if the provided key or the entire cache (if no key is provided)
+// is outdated based on the set TTL. Returns true if outdated, false otherwise.
+func (c *InMemoryHashMapMultiCache[K, T, H]) Outdated(key uopt.Opt[K]) bool {
+	c.vMtx.Lock()
+	defer c.vMtx.Unlock()
+
+	if c.ttl == nil {
+		return false
+	} else {
+		if key.Present() {
+			k := key.Get()
+			if lu, ok := c.lastUpdatedKeys[(*k).String()]; ok {
+				return time.Since(lu) > *c.ttl
+			} else {
+				return true
+			}
+		} else {
+			return time.Since(c.lastUpdated) > *c.ttl
+		}
+	}
+}
+
+func (c *InMemoryHashMapMultiCache[K, T, H]) dropAll() {
+	c.values = make(map[H][]T)
+	c.changes = nil
+}
+
+func (c *InMemoryHashMapMultiCache[K, T, H]) put(key K, values ...T) {
+	c.addTran(key, values...)
+	changes := len(c.changes) == 0
+	found := false
+	for _, diff := range c.changes {
+		if uarray.EqualsWithOrder(diff.Keys(), key.Keys()) {
+			if !diff.Equals(key) {
+				changes = true
+				break
+			}
+			found = true
+			continue
+		}
+	}
+	if changes || !found {
+		c.changes = append(c.changes, key)
+	}
+}
+
+func (c *InMemoryHashMapMultiCache[K, T, H]) addTran(key K, values ...T) {
+	keys := key.Keys()
+	if len(values) == 0 {
+		return
+	}
+
+	for i := 0; i < len(keys); i++ {
+		hash := c.toHash(keys[:i+1])
+		for _, value := range values {
+			if existing, found := c.values[hash]; found {
+				if ind, entry := uarray.ContainsPredicate[T](existing, func(v *T) bool {
+					return (*v).Equals(value)
+				}); entry == nil {
+					// Collision detected
+					c.values[hash] = append(existing, value)
+				} else {
+					// Else replace, this value is already hashed
+					c.values[hash][ind] = value
+				}
+			} else {
+				c.values[hash] = []T{value}
+			}
+		}
+	}
+}
+
+func (c *InMemoryHashMapMultiCache[K, T, H]) dropKey(keys []int64) {
+	delete(c.values, c.toHash(keys))
+}
+
+func intToBytes(buffer *bytes.Buffer, num int64) []byte {
+	buffer.Reset()
+	_ = binary.Write(buffer, binary.LittleEndian, num)
+
+	return buffer.Bytes()
+}

--- a/ucache/multicache_bench_test.go
+++ b/ucache/multicache_bench_test.go
@@ -1,0 +1,501 @@
+/*
+ * @Author: kordax, 10/5/23, 6:29 PM
+ */
+
+package ucache
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/kordax/basic-utils/uopt"
+)
+
+const (
+	numItems = 1000
+	stdDepth = 3
+)
+
+// prepareCacheIntKey populates the cache with IntKey items.
+func prepareCacheIntKey(c MultiCache[IntCompositeKey, Comparable], num int64) []IntCompositeKey {
+	keys := make([]IntCompositeKey, num)
+	for i := int64(0); i < num; i++ {
+		key := NewIntCompositeKey(i)
+		keys[i] = key
+		c.Put(key, NewInt64Value(i))
+	}
+
+	return keys
+}
+
+// prepareCacheIntKey populates the cache with IntKey items.
+func prepareCacheIntKeyWithDepth(c MultiCache[IntCompositeKey, Comparable], num, maxDepth int64) []IntCompositeKey {
+	keys := make([]IntCompositeKey, num)
+	for i := int64(0); i < num; i++ {
+		var hashes []int64
+		for h := int64(0); h < maxDepth; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+		c.Put(key, NewInt64Value(i))
+	}
+
+	return keys
+}
+
+func BenchmarkSha256HashMapMultiCachePutIntKeySingle(b *testing.B) {
+	c := NewSha256HashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := make([]IntCompositeKey, int64(b.N))
+	for i := int64(0); i < int64(b.N); i++ {
+		var hashes []int64
+		for h := int64(0); h < stdDepth; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+	}
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Put(keys[i], NewInt64Value(i))
+	}
+}
+
+func BenchmarkSha256HashMapMultiCachePutIntKeySingleDepth100(b *testing.B) {
+	c := NewSha256HashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := make([]IntCompositeKey, b.N)
+	for i := int64(0); i < int64(b.N); i++ {
+		var hashes []int64
+		for h := int64(0); h < 100; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+	}
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Put(keys[i], NewInt64Value(i))
+	}
+}
+
+func BenchmarkSha256HashMapMultiCachePutIntKeyConcurrent(b *testing.B) {
+	c := NewSha256HashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := make([]IntCompositeKey, b.N)
+	for i := int64(0); i < int64(b.N); i++ {
+		var hashes []int64
+		for h := int64(0); h < stdDepth; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Put(keys[int64(b.N-1)], NewInt64Value(int64(b.N)))
+		}
+	})
+}
+
+func BenchmarkSha256HashMapMultiCachePutIntKeyConcurrentDepth100(b *testing.B) {
+	c := NewSha256HashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := make([]IntCompositeKey, b.N+1)
+	for i := int64(0); i < int64(b.N); i++ {
+		var hashes []int64
+		for h := int64(0); h < 100; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Put(keys[int64(b.N-1)], NewInt64Value(int64(b.N)))
+		}
+	})
+}
+
+func BenchmarkSha256HashMapMultiCacheGetIntKeySingle(b *testing.B) {
+	c := NewSha256HashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, numItems)
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Get(keys[i%numItems])
+	}
+}
+
+func BenchmarkSha256HashMapMultiCacheGetIntKeySingleDeepDepth100(b *testing.B) {
+	c := NewSha256HashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKeyWithDepth(c, numItems, 100)
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Get(keys[i%numItems])
+	}
+}
+
+func BenchmarkSha256HashMapMultiCacheGetIntKeyConcurrent(b *testing.B) {
+	c := NewSha256HashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, numItems)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Get(keys[int64(b.N)%numItems])
+		}
+	})
+}
+
+func BenchmarkSha256HashMapMultiCacheSetIntKeySingle(b *testing.B) {
+	c := NewSha256HashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, numItems)
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Set(keys[i%numItems], NewInt64Value(i))
+	}
+}
+
+func BenchmarkSha256HashMapMultiCacheSetIntKeyConcurrent(b *testing.B) {
+	c := NewSha256HashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, numItems)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Set(keys[int64(b.N)%numItems], NewInt64Value(int64(b.N)))
+		}
+	})
+}
+
+func BenchmarkSha256HashMapMultiCacheGetIntKeySingle10xItems(b *testing.B) {
+	num := int64(numItems * 10)
+	c := NewSha256HashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, num)
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Get(keys[i%num])
+	}
+}
+
+func BenchmarkFarmHashMapMultiCachePutIntKeySingle(b *testing.B) {
+	c := NewFarmHashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := make([]IntCompositeKey, int64(b.N))
+	for i := int64(0); i < int64(b.N); i++ {
+		var hashes []int64
+		for h := int64(0); h < stdDepth; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+	}
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Put(keys[i], NewInt64Value(i))
+	}
+}
+
+func BenchmarkFarmHashMapMultiCachePutIntKeySingleDepth100(b *testing.B) {
+	c := NewFarmHashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := make([]IntCompositeKey, b.N)
+	for i := int64(0); i < int64(b.N); i++ {
+		var hashes []int64
+		for h := int64(0); h < 100; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+	}
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Put(keys[i], NewInt64Value(i))
+	}
+}
+
+func BenchmarkFarmHashMapMultiCachePutIntKeyConcurrent(b *testing.B) {
+	c := NewFarmHashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := make([]IntCompositeKey, b.N)
+	for i := int64(0); i < int64(b.N); i++ {
+		var hashes []int64
+		for h := int64(0); h < stdDepth; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Put(keys[int64(b.N-1)], NewInt64Value(int64(b.N)))
+		}
+	})
+}
+
+func BenchmarkFarmHashMapMultiCachePutIntKeyConcurrentDepth100(b *testing.B) {
+	c := NewFarmHashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := make([]IntCompositeKey, b.N+1)
+	for i := int64(0); i < int64(b.N); i++ {
+		var hashes []int64
+		for h := int64(0); h < 100; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Put(keys[int64(b.N-1)], NewInt64Value(int64(b.N)))
+		}
+	})
+}
+
+func BenchmarkFarmHashMapMultiCacheGetIntKeySingle(b *testing.B) {
+	c := NewFarmHashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, numItems)
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Get(keys[i%numItems])
+	}
+}
+
+func BenchmarkFarmHashMapMultiCacheGetIntKeySingleDeepDepth100(b *testing.B) {
+	c := NewFarmHashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKeyWithDepth(c, numItems, 100)
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Get(keys[i%numItems])
+	}
+}
+
+func BenchmarkFarmHashMapMultiCacheGetIntKeyConcurrent(b *testing.B) {
+	c := NewFarmHashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, numItems)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Get(keys[int64(b.N)%numItems])
+		}
+	})
+}
+
+func BenchmarkFarmHashMapMultiCacheSetIntKeySingle(b *testing.B) {
+	c := NewFarmHashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, numItems)
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Set(keys[i%numItems], NewInt64Value(i))
+	}
+}
+
+func BenchmarkFarmHashMapMultiCacheSetIntKeyConcurrent(b *testing.B) {
+	c := NewFarmHashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, numItems)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Set(keys[int64(b.N)%numItems], NewInt64Value(int64(b.N)))
+		}
+	})
+}
+
+func BenchmarkFarmHashMapMultiCacheGetIntKeySingle10xItems(b *testing.B) {
+	num := int64(numItems * 10)
+	c := NewFarmHashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, num)
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Get(keys[i%num])
+	}
+}
+
+func BenchmarkTreeMultiCachePutIntKeySingle(b *testing.B) {
+	c := NewInMemoryTreeMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := make([]IntCompositeKey, int64(b.N))
+	for i := int64(0); i < int64(b.N); i++ {
+		var hashes []int64
+		for h := int64(0); h < stdDepth; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+	}
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Put(keys[i], NewInt64Value(i))
+	}
+}
+
+func BenchmarkTreeMultiCachePutIntKeySingleDepth100(b *testing.B) {
+	c := NewInMemoryTreeMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := make([]IntCompositeKey, b.N)
+	for i := int64(0); i < int64(b.N); i++ {
+		var hashes []int64
+		for h := int64(0); h < 100; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+	}
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Put(keys[i], NewInt64Value(i))
+	}
+}
+
+func BenchmarkTreeMultiCachePutIntKeyConcurrent(b *testing.B) {
+	c := NewInMemoryTreeMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := make([]IntCompositeKey, b.N)
+	for i := int64(0); i < int64(b.N); i++ {
+		var hashes []int64
+		for h := int64(0); h < stdDepth; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Put(keys[int64(b.N-1)], NewInt64Value(int64(b.N)))
+		}
+	})
+}
+
+func BenchmarkTreeMultiCachePutIntKeyConcurrentDepth100(b *testing.B) {
+	c := NewInMemoryTreeMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := make([]IntCompositeKey, b.N+1)
+	for i := int64(0); i < int64(b.N); i++ {
+		var hashes []int64
+		for h := int64(0); h < 100; h++ {
+			hashes = append(hashes, h)
+		}
+		key := NewIntCompositeKey(hashes...)
+		keys[i] = key
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Put(keys[int64(b.N-1)], NewInt64Value(int64(b.N)))
+		}
+	})
+}
+
+func BenchmarkTreeMultiCacheGetIntKeySingle(b *testing.B) {
+	c := NewInMemoryTreeMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, numItems)
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Get(keys[i%numItems])
+	}
+}
+
+func BenchmarkTreeMultiCacheGetIntKeySingleDeepDepth100(b *testing.B) {
+	c := NewInMemoryTreeMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKeyWithDepth(c, numItems, 100)
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Get(keys[i%numItems])
+	}
+}
+
+func BenchmarkTreeMultiCacheGetIntKeyConcurrent(b *testing.B) {
+	c := NewInMemoryTreeMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, numItems)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Get(keys[int64(b.N)%numItems])
+		}
+	})
+}
+
+func BenchmarkTreeMultiCacheSetIntKeySingle(b *testing.B) {
+	c := NewInMemoryTreeMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, numItems)
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Set(keys[i%numItems], NewInt64Value(i))
+	}
+}
+
+func BenchmarkTreeMultiCacheSetIntKeyConcurrent(b *testing.B) {
+	c := NewInMemoryTreeMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, numItems)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.Set(keys[int64(b.N)%numItems], NewInt64Value(int64(b.N)))
+		}
+	})
+}
+
+func BenchmarkTreeMultiCacheGetIntKeySingle10xItems(b *testing.B) {
+	num := int64(numItems * 10)
+	c := NewInMemoryTreeMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	keys := prepareCacheIntKey(c, num)
+	b.ResetTimer()
+
+	for i := int64(0); i < int64(b.N); i++ {
+		c.Get(keys[i%num])
+	}
+}
+
+func BenchmarkMemoryFarmHashMapMultiCache(b *testing.B) {
+	c := NewFarmHashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	benchmarkMemoryUsage(b, c)
+}
+
+func BenchmarkMemorySha256HashMapMultiCache(b *testing.B) {
+	c := NewSha256HashMapMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	benchmarkMemoryUsage(b, c)
+}
+
+func BenchmarkMemoryTreeMultiCache(b *testing.B) {
+	c := NewInMemoryTreeMultiCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
+	benchmarkMemoryUsage(b, c)
+}
+
+func benchmarkMemoryUsage(b *testing.B, c MultiCache[IntCompositeKey, Comparable]) {
+	var m runtime.MemStats
+
+	for i := int64(0); i < numItems; i++ {
+		key := NewIntCompositeKey(i)
+		c.Put(key, NewInt64Value(i))
+	}
+
+	runtime.ReadMemStats(&m)
+	b.Logf("Memory Alloc = %v KB", bToKb(m.Alloc))
+}
+
+// Helper function to convert bytes to KB.
+func bToKb(b uint64) uint64 {
+	return b / 1024
+}

--- a/ucache/multicache_test.go
+++ b/ucache/multicache_test.go
@@ -1,0 +1,487 @@
+package ucache_test
+
+import (
+	"math/rand"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kordax/basic-utils/ucache"
+	"github.com/kordax/basic-utils/uopt"
+	"github.com/stretchr/testify/assert"
+)
+
+type DummyComparable struct {
+	Val int
+}
+
+func (d DummyComparable) Hash() int {
+	return d.Val<<31 + d.Val
+}
+
+func (d DummyComparable) Equals(other ucache.Comparable) bool {
+	switch o := other.(type) {
+	case DummyComparable:
+		return d.Val == o.Val
+	default:
+		return false
+	}
+}
+
+//goland:noinspection GoUnusedExportedType
+type SimpleKey int64
+
+func (s SimpleKey) Equals(other ucache.Comparable) bool {
+	return s == other
+}
+
+func (s SimpleKey) Key() int64 {
+	return int64(s)
+}
+
+func (s SimpleKey) String() string {
+	return strconv.Itoa(int(s))
+}
+
+type SimpleCompositeKey[T ucache.Hashed] struct {
+	keys []T
+}
+
+func (s SimpleCompositeKey[T]) Equals(other ucache.Comparable) bool {
+	switch o := other.(type) {
+	case SimpleCompositeKey[T]:
+		for i, k := range s.keys {
+			if len(s.keys) != len(o.keys) {
+				return false
+			}
+			if k.Key() != o.keys[i].Key() || !k.Equals(o.keys[i]) {
+				return false
+			}
+		}
+
+		return true
+	default:
+		return false
+	}
+}
+
+func (s SimpleCompositeKey[T]) Keys() []int64 {
+	result := make([]int64, len(s.keys))
+	for i, key := range s.keys {
+		result[i] = key.Key()
+	}
+
+	return result
+}
+
+func (s SimpleCompositeKey[T]) String() string {
+	rep := make([]string, len(s.keys))
+	for i, key := range s.keys {
+		rep[i] = key.String()
+	}
+
+	return strings.Join(rep, ", ")
+}
+
+func NewSimpleCompositeKey[T ucache.Hashed](keys ...T) SimpleCompositeKey[T] {
+	return SimpleCompositeKey[T]{keys: keys}
+}
+
+func TestHashMapMultiCache(t *testing.T) {
+	c := ucache.NewDefaultHashMapMultiCache[SimpleCompositeKey[ucache.StringKey], DummyComparable](uopt.Null[time.Duration]())
+	key := NewSimpleCompositeKey[ucache.StringKey]("atest")
+	key2 := NewSimpleCompositeKey[ucache.StringKey]("bSeCond-keyQ@!%!%#")
+	val := 326
+	c.Put(key, DummyComparable{Val: val})
+
+	changes := c.Changes()
+	assert.NotNil(t, changes)
+	cached := c.Get(key)
+	assert.Contains(t, cached, DummyComparable{Val: val})
+
+	assert.Empty(t, c.Changes())
+	for i := 0; i < 10; i++ {
+		c.Put(key, DummyComparable{Val: i})
+	}
+	c.Put(key2, DummyComparable{Val: 65535})
+	changes = c.Changes()
+	assert.EqualValues(t, []SimpleCompositeKey[ucache.StringKey]{key, key2}, changes)
+
+	result := c.Get(key2)
+	assert.Contains(t, result, DummyComparable{Val: 65535})
+
+	complexKeyBase := []ucache.StringKey{"p1", "p2", "p3"}
+	partialComplexKey := NewSimpleCompositeKey[ucache.StringKey](complexKeyBase...)
+
+	for i := 0; i < 10; i++ {
+		complexKey := NewSimpleCompositeKey[ucache.StringKey](append(complexKeyBase, ucache.StringKey("number:"+strconv.Itoa(i)))...)
+		c.Put(complexKey, DummyComparable{Val: i})
+		changes = c.Changes()
+		assert.Contains(t, changes, complexKey)
+	}
+
+	result = c.Get(partialComplexKey)
+	assert.NotEmpty(t, result)
+	for i := 0; i < 10; i++ {
+		assert.Contains(t, result, DummyComparable{i})
+	}
+}
+
+func TestHashMapMultiCache_CompositeKey(t *testing.T) {
+	c := ucache.NewDefaultHashMapMultiCache[ucache.StrCompositeKey, DummyComparable](uopt.Null[time.Duration]())
+	key := ucache.NewStrCompositeKey("category", "kp_2")
+	key2 := ucache.NewStrCompositeKey("category2", "kp_2")
+	val := DummyComparable{Val: 10}
+	val2 := DummyComparable{Val: 236261}
+
+	c.PutQuietly(key, val)
+	c.PutQuietly(key2, val2)
+
+	results := c.Get(key)
+	results2 := c.Get(key2)
+	assert.Len(t, results, 1)
+	assert.Len(t, results, 1)
+	assert.EqualValues(t, results[0], val)
+	assert.EqualValues(t, results2[0], val2)
+}
+
+func TestHashMapMultiCache_DropKey(t *testing.T) {
+	c := ucache.NewDefaultHashMapMultiCache[ucache.StrCompositeKey, DummyComparable](uopt.Null[time.Duration]())
+	categoryKey := ucache.NewStrCompositeKey("category")
+	key := ucache.NewStrCompositeKey("category", "kp_232626")
+	key2 := ucache.NewStrCompositeKey("category2", "kp_232626")
+	catVal := DummyComparable{Val: rand.Int()}
+	val := DummyComparable{Val: rand.Int()}
+	val2 := DummyComparable{Val: rand.Int()}
+
+	c.Put(categoryKey, catVal)
+	c.Put(key, val)
+	c.Put(key2, val2)
+
+	catRes := c.Get(categoryKey)
+	res := c.Get(key)
+	res2 := c.Get(key2)
+	assert.Len(t, catRes, 2)
+	assert.Len(t, res, 1)
+	assert.Len(t, res2, 1)
+
+	c.DropKey(key)
+	catRes = c.Get(categoryKey)
+	res = c.Get(key)
+	res2 = c.Get(key2)
+	assert.Len(t, catRes, 2)
+	assert.Len(t, res, 0)
+	assert.Len(t, res2, 1)
+}
+
+func TestHashMapMultiCache_PutQuietly(t *testing.T) {
+	c := ucache.NewDefaultHashMapMultiCache[SimpleCompositeKey[ucache.StringKey], DummyComparable](uopt.Null[time.Duration]())
+	key := NewSimpleCompositeKey[ucache.StringKey]("kp_1", "kp_2")
+	val := DummyComparable{Val: 10}
+	val2 := DummyComparable{Val: 15}
+
+	c.PutQuietly(key, val)
+	c.PutQuietly(key, val)
+	c.PutQuietly(key, val)
+
+	results := c.Get(key)
+	assert.Len(t, results, 1)
+
+	c.PutQuietly(key, val2)
+	results = c.Get(key)
+	assert.Len(t, results, 2)
+
+	c.PutQuietly(key, val)
+	results = c.Get(key)
+	assert.Len(t, results, 2)
+}
+
+func TestTreeMultiCache(t *testing.T) {
+	c := ucache.NewInMemoryTreeMultiCache[SimpleCompositeKey[ucache.StringKey], DummyComparable](uopt.Null[time.Duration]())
+	key := NewSimpleCompositeKey[ucache.StringKey]("atest")
+	key2 := NewSimpleCompositeKey[ucache.StringKey]("bSeCond-keyQ@!%!%#")
+	val := 326
+	c.Put(key, DummyComparable{Val: val})
+
+	changes := c.Changes()
+	assert.NotNil(t, changes)
+	cached := c.Get(key)
+	assert.Contains(t, cached, DummyComparable{Val: val})
+
+	assert.Empty(t, c.Changes())
+	for i := 0; i < 10; i++ {
+		c.Put(key, DummyComparable{Val: i})
+	}
+	c.Put(key2, DummyComparable{Val: 65535})
+	changes = c.Changes()
+	assert.EqualValues(t, []SimpleCompositeKey[ucache.StringKey]{key, key2}, changes)
+
+	result := c.Get(key2)
+	assert.Contains(t, result, DummyComparable{Val: 65535})
+
+	complexKeyBase := []ucache.StringKey{"p1", "p2", "p3"}
+	partialComplexKey := NewSimpleCompositeKey[ucache.StringKey](complexKeyBase...)
+
+	for i := 0; i < 10; i++ {
+		complexKey := NewSimpleCompositeKey[ucache.StringKey](append(complexKeyBase, ucache.StringKey("number:"+strconv.Itoa(i)))...)
+		c.Put(complexKey, DummyComparable{Val: i})
+		changes = c.Changes()
+		assert.Contains(t, changes, complexKey)
+	}
+
+	result = c.Get(partialComplexKey)
+	assert.NotEmpty(t, result)
+	for i := 0; i < 10; i++ {
+		assert.Contains(t, result, DummyComparable{i})
+	}
+}
+
+func TestTreeMultiCache_CompositeKey(t *testing.T) {
+	c := ucache.NewInMemoryTreeMultiCache[ucache.StrCompositeKey, DummyComparable](uopt.Null[time.Duration]())
+	key := ucache.NewStrCompositeKey("category", "kp_2")
+	key2 := ucache.NewStrCompositeKey("category2", "kp_2")
+	val := DummyComparable{Val: 10}
+	val2 := DummyComparable{Val: 236261}
+
+	c.PutQuietly(key, val)
+	c.PutQuietly(key2, val2)
+
+	results := c.Get(key)
+	results2 := c.Get(key2)
+	assert.Len(t, results, 1)
+	assert.Len(t, results, 1)
+	assert.EqualValues(t, results[0], val)
+	assert.EqualValues(t, results2[0], val2)
+}
+
+func TestTreeMultiCache_DropKey(t *testing.T) {
+	c := ucache.NewInMemoryTreeMultiCache[ucache.StrCompositeKey, DummyComparable](uopt.Null[time.Duration]())
+	categoryKey := ucache.NewStrCompositeKey("category")
+	key := ucache.NewStrCompositeKey("category", "kp_232626")
+	key2 := ucache.NewStrCompositeKey("category2", "kp_232626")
+	catVal := DummyComparable{Val: rand.Int()}
+	val := DummyComparable{Val: rand.Int()}
+	val2 := DummyComparable{Val: rand.Int()}
+
+	c.Put(categoryKey, catVal)
+	c.Put(key, val)
+	c.Put(key2, val2)
+
+	catRes := c.Get(categoryKey)
+	res := c.Get(key)
+	res2 := c.Get(key2)
+	assert.Len(t, catRes, 2)
+	assert.Len(t, res, 1)
+	assert.Len(t, res2, 1)
+
+	c.DropKey(key)
+	catRes = c.Get(categoryKey)
+	res = c.Get(key)
+	res2 = c.Get(key2)
+	assert.Len(t, catRes, 1)
+	assert.Len(t, res, 0)
+	assert.Len(t, res2, 1)
+}
+
+func TestTreeMultiCache_AddTransparent(t *testing.T) {
+	c := ucache.NewInMemoryTreeMultiCache[SimpleCompositeKey[ucache.StringKey], DummyComparable](uopt.Null[time.Duration]())
+	key := NewSimpleCompositeKey[ucache.StringKey]("kp_1", "kp_2")
+	val := DummyComparable{Val: 10}
+	val2 := DummyComparable{Val: 15}
+
+	c.PutQuietly(key, val)
+	c.PutQuietly(key, val)
+	c.PutQuietly(key, val)
+
+	results := c.Get(key)
+	assert.Len(t, results, 1)
+
+	c.PutQuietly(key, val2)
+	results = c.Get(key)
+	assert.Len(t, results, 2)
+
+	c.PutQuietly(key, val)
+	results = c.Get(key)
+	assert.Len(t, results, 2)
+}
+
+func TestNewGenericCompositeKey(t *testing.T) {
+	c := ucache.NewInMemoryTreeMultiCache[ucache.GenericCompositeKey, DummyComparable](uopt.Null[time.Duration]())
+	key1 := ucache.NewGenericCompositeKey("KeyString", 2, 3.0, uint8(4), int16(-5))
+	key2 := ucache.NewGenericCompositeKey("KeyString", 2, 3.0, int8(100), uint16(5))
+	subKey1 := ucache.NewGenericCompositeKey("KeyString", 2, 3.0, uint8(4))
+	subKey2 := ucache.NewGenericCompositeKey("KeyString", 2, 3.0, int8(100))
+	baseKey := ucache.NewGenericCompositeKey("KeyString", 2, 3.0)
+
+	var firstKeyDummies []DummyComparable
+	for i := 0; i < 2; i++ {
+		firstKeyDummies = append(firstKeyDummies, DummyComparable{Val: i})
+	}
+	var secondKeyDummies []DummyComparable
+	for i := 2; i < 7; i++ {
+		secondKeyDummies = append(secondKeyDummies, DummyComparable{Val: i})
+	}
+
+	sort.Slice(firstKeyDummies, func(i, j int) bool {
+		return firstKeyDummies[i].Val < (firstKeyDummies[j].Val)
+	})
+	sort.Slice(secondKeyDummies, func(i, j int) bool {
+		return secondKeyDummies[i].Val < (secondKeyDummies[j].Val)
+	})
+
+	c.Put(key1, firstKeyDummies...)
+	c.Put(key2, secondKeyDummies...)
+
+	changes := c.Changes()
+	assert.NotNil(t, changes)
+	key1Result := c.Get(key1)
+	assert.EqualValues(t, firstKeyDummies, key1Result)
+	key2Result := c.Get(key2)
+	assert.EqualValues(t, secondKeyDummies, key2Result)
+	subKey1Result := c.Get(subKey1)
+	assert.EqualValues(t, firstKeyDummies, subKey1Result)
+	subKey2Result := c.Get(subKey2)
+	assert.EqualValues(t, secondKeyDummies, subKey2Result)
+	baseKeyResult := c.Get(baseKey)
+
+	combinedDummies := append(firstKeyDummies, secondKeyDummies...)
+	sort.Slice(combinedDummies, func(i, j int) bool {
+		return combinedDummies[i].Val < (combinedDummies[j].Val)
+	})
+	sort.Slice(baseKeyResult, func(i, j int) bool {
+		return baseKeyResult[i].Val < (baseKeyResult[j].Val)
+	})
+
+	assert.EqualValues(t, combinedDummies, baseKeyResult)
+}
+
+type CollisionTestKey struct {
+	id   int
+	hash []int64
+}
+
+// Implement the CompositeKey interface for TestKey
+func (k CollisionTestKey) Keys() []int64 {
+	return k.hash
+}
+
+func (k CollisionTestKey) String() string {
+	return strconv.Itoa(k.id)
+}
+
+func (k CollisionTestKey) Equals(other ucache.Comparable) bool {
+	ok, _ := other.(CollisionTestKey)
+	return k.id == ok.id
+}
+
+func TestTreeMultiCacheHighCollisionProbability(t *testing.T) {
+	c := ucache.NewInMemoryTreeMultiCache[CollisionTestKey, ucache.Int64Value](uopt.Null[time.Duration]())
+
+	// Define a set of keys that all produce the same hash code
+	keys := []CollisionTestKey{
+		{id: 1, hash: []int64{1, 2, 3}},
+		{id: 2, hash: []int64{1, 2, 3}},
+		{id: 3, hash: []int64{1, 2, 3}},
+	}
+
+	// Add values to the c for each key
+	for i, key := range keys {
+		c.Put(key, ucache.NewInt64Value(int64(i)))
+	}
+
+	// Ensure that all values can be retrieved despite the high collision probability
+	for i, key := range keys {
+		values := c.Get(key)
+		assert.Contains(t, values, ucache.NewInt64Value(int64(i))) // Check if the expected value is present in the retrieved values
+	}
+}
+
+func TestInMemoryTreeMultiCache_Set(t *testing.T) {
+	c := ucache.NewInMemoryTreeMultiCache[ucache.StrCompositeKey, ucache.StringValue](uopt.Null[time.Duration]())
+	key := ucache.NewStrCompositeKey("key1")
+	value1 := ucache.NewStringValue("value1")
+	value2 := ucache.NewStringValue("value2")
+
+	c.Set(key, value1)
+	retrieved := c.Get(key)
+	assert.Len(t, retrieved, 1)
+	assert.Equal(t, value1, retrieved[0])
+
+	c.Set(key, value2)
+	retrieved = c.Get(key)
+	assert.Len(t, retrieved, 1)
+	assert.Equal(t, value2, retrieved[0])
+}
+
+func TestInMemoryTreeMultiCache_Outdated_WithStringKeyAndValue(t *testing.T) {
+	ttl := 1 * time.Millisecond
+	longTTL := 1 * time.Hour
+	c := ucache.NewInMemoryTreeMultiCache[ucache.StrCompositeKey, ucache.StringValue](uopt.Of(ttl))
+	cLong := ucache.NewInMemoryTreeMultiCache[ucache.StrCompositeKey, ucache.StringValue](uopt.Of(longTTL))
+
+	key1 := ucache.NewStrCompositeKey("key1")
+	key2 := ucache.NewStrCompositeKey("key2")
+	value1 := ucache.NewStringValue("value1")
+
+	// Test with long TTL
+	assert.True(t, cLong.Outdated(uopt.Null[ucache.StrCompositeKey]()))
+	cLong.Put(key1, value1)
+	assert.False(t, cLong.Outdated(uopt.Of(key1)))
+	time.Sleep(10 * time.Millisecond)
+	assert.False(t, cLong.Outdated(uopt.Of(key1)))
+
+	// Test immediate expiration
+	assert.True(t, c.Outdated(uopt.Null[ucache.StrCompositeKey]()))
+	c.Put(key1, value1)
+	assert.False(t, c.Outdated(uopt.Of(key1)))
+	time.Sleep(ttl + 10*time.Millisecond)
+	assert.True(t, c.Outdated(uopt.Of(key1)))
+
+	// Test overwriting key resets TTL
+	c.Put(key1, value1)
+	time.Sleep(ttl / 2)
+	c.Put(key1, value1) // Reset TTL
+	assert.False(t, c.Outdated(uopt.Of(key1)))
+	assert.False(t, c.Outdated(uopt.Of(key1)))
+	time.Sleep(ttl)
+	assert.True(t, c.Outdated(uopt.Of(key1)))
+
+	// Test Drop() method
+	c.Put(key1, value1)
+	c.Put(key2, value1)
+	c.Drop()
+	assert.True(t, c.Outdated(uopt.Of(key1)))
+	assert.True(t, c.Outdated(uopt.Of(key2)))
+}
+
+func TestInMemoryTreeMultiCache_Outdated_WithDifferentTTLs(t *testing.T) {
+	shortTTL := 10 * time.Millisecond
+	mediumTTL := 20 * time.Millisecond
+	longTTL := 30 * time.Millisecond
+
+	cShort := ucache.NewInMemoryTreeMultiCache[ucache.StrCompositeKey, ucache.StringValue](uopt.Of(shortTTL))
+	cMedium := ucache.NewInMemoryTreeMultiCache[ucache.StrCompositeKey, ucache.StringValue](uopt.Of(mediumTTL))
+	cLong := ucache.NewInMemoryTreeMultiCache[ucache.StrCompositeKey, ucache.StringValue](uopt.Of(longTTL))
+
+	key := ucache.NewStrCompositeKey("key")
+
+	value := ucache.NewStringValue("value")
+
+	cShort.Put(key, value)
+	cMedium.Put(key, value)
+	cLong.Put(key, value)
+
+	time.Sleep(shortTTL + 1*time.Millisecond)
+	assert.True(t, cShort.Outdated(uopt.Of(key)))
+	assert.False(t, cMedium.Outdated(uopt.Of(key)))
+	assert.False(t, cLong.Outdated(uopt.Of(key)))
+
+	time.Sleep(mediumTTL - shortTTL)
+	assert.True(t, cMedium.Outdated(uopt.Of(key)))
+	assert.False(t, cLong.Outdated(uopt.Of(key)))
+
+	time.Sleep(longTTL - mediumTTL)
+	assert.True(t, cLong.Outdated(uopt.Of(key)))
+}

--- a/ucache/types_test.go
+++ b/ucache/types_test.go
@@ -301,7 +301,7 @@ func TestStringValue_Equals(t *testing.T) {
 }
 
 func TestKeysWithCache(t *testing.T) {
-	cache := ucache.NewInMemoryTreeCache[ucache.CompositeKey, ucache.StringValue](uopt.NullDuration())
+	cache := ucache.NewInMemoryTreeMultiCache[ucache.CompositeKey, ucache.StringValue](uopt.NullDuration())
 
 	intKey := ucache.IntKey(42)
 	cache.Put(intKey, ucache.NewStringValue("value for int"))

--- a/ucache/ucache.go
+++ b/ucache/ucache.go
@@ -1,9 +1,13 @@
+/*
+ * @kordax (Dmitry Morozov)
+ * dmorozov@valoru-software.com
+ * Copyright (c) 2024.
+ */
+
 package ucache
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/binary"
 	"sync"
 	"time"
 
@@ -12,324 +16,43 @@ import (
 	"github.com/kordax/basic-utils/uopt"
 )
 
-type container[K CompositeKey, T Comparable] struct {
-	pairs map[int64][]uarray.Pair[K, T]
-	node  map[int64]any
-}
+// The Cache interface defines a set of methods for a generic cache implementation.
+// This interface supports setting, getting, and managing cache entries with composite keys.
+// Unlike MultiCache, it is designed to handle only one value per key.
+type Cache[K CompositeKey, T any] interface {
+	// Set updates the cache value for the provided key. If the key already exists,
+	// its previous value is removed before adding the new value. This method should be thread-safe.
+	Set(key K, value T)
 
-type Cache[K CompositeKey, T Comparable] interface {
-	Put(key K, values ...T) // Adds a new value to the key
-	Set(key K, values ...T) // Overwrites key values
-	Get(key K) []T
-	Changes() []K
+	// Get retrieves the value associated with the provided key from the cache.
+	// It returns the value and a boolean indicating whether the key was found.
+	// This method should be thread-safe.
+	Get(key K) (*T, bool)
+
+	// Drop completely clears the cache, removing all entries. This method should be thread-safe.
 	Drop()
+
+	// DropKey removes the value associated with the provided key from the cache. This method should be thread-safe.
 	DropKey(key K)
+
+	// Outdated checks if the provided key or the entire cache (if no key is provided)
+	// is outdated based on the set TTL (time-to-live). Returns true if outdated, false otherwise.
+	// This method should be thread-safe.
 	Outdated(key uopt.Opt[K]) bool
 
-	PutQuietly(key K, values ...T) // Adds the values but update cache state/doesn't add any changes to the cache
+	// SetQuietly is an optimized method adds a value to the cache for the provided key but does so without
+	// altering the change history. This method is useful when modifications should not trigger cache change diff.
+	// This method should be thread-safe.
+	// This operation is much faster and can be used to optimize cache performance in case you don't want to track changes.
+	SetQuietly(key K, value T)
 }
 
-// InMemoryTreeCache provides an in-memory caching mechanism with support for compound keys.
-// The cache leverages tree-like structures to store and organize data, allowing efficient
-// operations even with composite keys. The cache supports optional TTL (time-to-live) for entries,
-// ensuring that outdated entries can be identified and potentially purged. Concurrency-safe
-// operations are ensured through the use of a mutex.
-//
-// Benchmark insights:
-// - Put operation performance is fast for shallow depth keys but slows down as the depth increases.
-// - Get operation is particularly efficient, especially for shallow depth keys.
-// - Set operation's performance is consistent regardless of the depth of the key.
-type InMemoryTreeCache[K CompositeKey, T Comparable] struct {
-	values  map[int64]any
-	changes []K
-
-	lastUpdatedKeys map[string]time.Time
-	lastUpdated     time.Time
-	ttl             *time.Duration
-
-	vMtx sync.Mutex
-}
-
-// NewInMemoryTreeCache creates a new instance of the InMemoryTreeCache.
-// It takes an optional TTL (time-to-live) parameter to set expiration time for cache entries.
-// If the TTL is not provided, cache entries will not expire.
-func NewInMemoryTreeCache[K CompositeKey, T Comparable](ttl uopt.Opt[time.Duration]) *InMemoryTreeCache[K, T] {
-	c := &InMemoryTreeCache[K, T]{
-		values:          make(map[int64]any),
-		changes:         make([]K, 0),
-		lastUpdatedKeys: make(map[string]time.Time),
-	}
-	ttl.IfPresent(func(t time.Duration) {
-		c.ttl = &t
-	})
-
-	return c
-}
-
-// Put inserts a new value(s) into the cache associated with the given key.
-// If the key already exists in the cache, it appends the new value(s) to the existing values.
-// This operation is relatively fast for shallow depth keys, but becomes slower as the depth increases.
-func (c *InMemoryTreeCache[K, T]) Put(key K, val ...T) {
-	c.vMtx.Lock()
-	defer c.vMtx.Unlock()
-	c.put(key, val...)
-	c.lastUpdatedKeys[key.String()] = time.Now()
-	c.lastUpdated = time.Now()
-}
-
-// Set inserts a new value(s) into the cache associated with the given key.
-// If the key already exists in the cache, this method will overwrite the existing values.
-func (c *InMemoryTreeCache[K, T]) Set(key K, val ...T) {
-	c.vMtx.Lock()
-	defer c.vMtx.Unlock()
-	c.dropKeyRecursively(key.Keys(), 0, c.values)
-	c.put(key, val...)
-	c.lastUpdatedKeys[key.String()] = time.Now()
-	c.lastUpdated = time.Now()
-}
-
-// AddSilently behaves like the Put method but does not update the cache state or add any changes to the cache.
-// This method is useful when you want to add values to the cache without triggering any side effects.
-func (c *InMemoryTreeCache[K, T]) PutQuietly(key K, val ...T) {
-	c.vMtx.Lock()
-	defer c.vMtx.Unlock()
-	c.addTran(key, val...)
-	c.lastUpdatedKeys[key.String()] = time.Now()
-	c.lastUpdated = time.Now()
-}
-
-// Get retrieves the value(s) associated with the given key from the cache.
-// If the key is not found, it returns an empty slice.
-// Retrieval is fast, especially for shallow depth keys.
-func (c *InMemoryTreeCache[K, T]) Get(key K) []T {
-	c.vMtx.Lock()
-	defer c.vMtx.Unlock()
-	c.changes = nil
-	bucket := c.tryToGetBucket(key.Keys())
-	result := make([]T, 0)
-	for _, pairs := range bucket {
-		for _, p := range pairs {
-			result = append(result, p.Right)
-		}
-	}
-
-	return result
-}
-
-// Changes returns a slice of keys that have been modified in the cache.
-// This method provides a way to track changes made to the cache, useful for scenarios like cache syncing.
-func (c *InMemoryTreeCache[K, T]) Changes() []K {
-	return c.changes
-}
-
-// Drop removes all entries from the cache.
-// This is a complete reset of the cache, useful when you want to clear the cache and start fresh.
-func (c *InMemoryTreeCache[K, T]) Drop() {
-	c.vMtx.Lock()
-	defer c.vMtx.Unlock()
-	c.dropAll()
-	c.lastUpdatedKeys = make(map[string]time.Time)
-}
-
-// DropKey removes the value(s) associated with the given key from the cache.
-func (c *InMemoryTreeCache[K, T]) DropKey(key K) {
-	c.vMtx.Lock()
-	defer c.vMtx.Unlock()
-	c.dropKeyRecursively(key.Keys(), 0, c.values)
-	c.lastUpdatedKeys[key.String()] = time.Now()
-	c.lastUpdated = time.Now()
-}
-
-// Outdated checks if a given key or the entire cache is outdated based on the TTL.
-// If no key is provided or key was not found, it checks the last updated time of the entire cache.
-// If a key is provided and found, it checks the last updated time of that specific key.
-func (c *InMemoryTreeCache[K, T]) Outdated(key uopt.Opt[K]) bool {
-	if !key.Present() {
-		return time.Since(c.lastUpdated) > *c.ttl
-	}
-
-	c.vMtx.Lock()
-	defer c.vMtx.Unlock()
-
-	if c.ttl == nil {
-		return false
-	} else {
-		if key.Present() {
-			k := key.Get()
-			if lu, ok := c.lastUpdatedKeys[(*k).String()]; ok {
-				return time.Since(lu) > *c.ttl
-			} else {
-				return true
-			}
-		} else {
-			return time.Since(c.lastUpdated) > *c.ttl
-		}
-	}
-}
-
-func (c *InMemoryTreeCache[K, T]) dropAll() {
-	c.values = make(map[int64]any)
-	c.changes = nil
-}
-
-func (c *InMemoryTreeCache[K, T]) put(key K, val ...T) {
-	c.addTran(key, val...)
-	changes := len(c.changes) == 0
-	found := false
-	for _, diff := range c.changes {
-		if uarray.EqualsWithOrder(diff.Keys(), key.Keys()) {
-			if !diff.Equals(key) {
-				changes = true
-				break
-			}
-			found = true
-			continue
-		}
-	}
-	if changes || !found {
-		c.changes = append(c.changes, key)
-	}
-}
-
-func (c *InMemoryTreeCache[K, T]) addTran(key K, values ...T) {
-	hashes := key.Keys()
-	if len(hashes) == 0 {
-		return
-	}
-
-	bucket := c.tryToGetBucket(hashes)
-	lHash := key.Keys()[len(hashes)-1]
-
-	for _, value := range values {
-		if ind, _ := uarray.ContainsPredicate(bucket[lHash], func(v *uarray.Pair[K, T]) bool {
-			return v.Right.Equals(value)
-		}); ind > -1 {
-			bucket[lHash][ind] = *uarray.NewPair[K, T](key, value)
-		} else {
-			bucket[lHash] = append(bucket[lHash], *uarray.NewPair[K, T](key, value))
-		}
-	}
-}
-
-func (c *InMemoryTreeCache[K, T]) dropKeyRecursively(keys []int64, n int, bucket map[int64]any) {
-	hash := keys[n]
-	interBucket := bucket[hash]
-	if interBucket != nil {
-		switch b := interBucket.(type) {
-		case container[K, T]:
-			if n+1 == len(keys) {
-				delete(bucket, hash)
-			} else {
-				c.dropKeyRecursively(keys, n+1, b.node)
-			}
-		default:
-			delete(bucket, hash)
-		}
-	}
-}
-
-func (c *InMemoryTreeCache[K, T]) tryToGetBucket(keys []int64) map[int64][]uarray.Pair[K, T] {
-	return c.getBucket(keys, 0, c.values)
-}
-
-func (c *InMemoryTreeCache[K, T]) getBucket(keys []int64, n int, interBucket map[int64]any) map[int64][]uarray.Pair[K, T] {
-	if keys == nil || n >= len(keys) {
-		return nil
-	}
-
-	if bucket, ok := interBucket[keys[n]]; ok {
-		switch b := bucket.(type) {
-		case map[int64][]uarray.Pair[K, T]:
-			if n+1 < len(keys) {
-				interBucket[keys[n]] = container[K, T]{
-					node:  make(map[int64]any),
-					pairs: b,
-				}
-				return c.getBucket(keys, n+1, interBucket[keys[n]].(container[K, T]).node)
-			} else {
-				return b
-			}
-		case container[K, T]:
-			if n+1 == len(keys) {
-				result := make(map[int64][]uarray.Pair[K, T])
-				for k, e := range b.pairs {
-					result[k] = append(result[k], e...)
-				}
-				if b.node != nil {
-					result = c.getNodePairsFlat(b.node, result)
-				}
-
-				return result
-			}
-
-			return c.getBucket(keys, n+1, b.node)
-		}
-	} else {
-		if n+1 == len(keys) {
-			interBucket[keys[n]] = map[int64][]uarray.Pair[K, T]{
-				keys[n]: nil,
-			}
-			return interBucket[keys[n]].(map[int64][]uarray.Pair[K, T])
-		} else {
-			if entry, ok := interBucket[keys[n]]; !ok {
-				interBucket[keys[n]] = container[K, T]{
-					node:  make(map[int64]any),
-					pairs: make(map[int64][]uarray.Pair[K, T]),
-				}
-				return c.getBucket(keys, n+1, interBucket[keys[n]].(container[K, T]).node)
-			} else {
-				switch e := entry.(type) {
-				case map[int64][]uarray.Pair[K, T]:
-					interBucket[keys[n]] = container[K, T]{
-						node:  make(map[int64]any),
-						pairs: e,
-					}
-					return c.getBucket(keys, n+1, interBucket[keys[n]].(container[K, T]).node)
-				case container[K, T]:
-					interBucket[keys[n]] = container[K, T]{
-						pairs: e.pairs,
-					}
-					return c.getBucket(keys, n+1, e.node)
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func (c *InMemoryTreeCache[K, T]) getNodePairsFlat(node map[int64]any, result map[int64][]uarray.Pair[K, T]) map[int64][]uarray.Pair[K, T] {
-	for _, entry := range node {
-		switch e := entry.(type) {
-		case map[int64][]uarray.Pair[K, T]:
-			for hash, pair := range e {
-				result[hash] = append(result[hash], pair...)
-			}
-		case container[K, T]:
-			for hash, pair := range e.pairs {
-				result[hash] = append(result[hash], pair...)
-			}
-			result = c.getNodePairsFlat(e.node, result)
-		}
-	}
-
-	return result
-}
-
-// InMemoryHashMapCache provides an in-memory caching mechanism using hashmaps.
-// This cache structure translates composite keys into a hash value using a user-provided
-// hashing function. The cache supports optional TTL (time-to-live) for entries.
-// Concurrency-safe operations are ensured through the use of a mutex.
-//
-// Performance Comparison with InMemoryTreeCache:
-// - Insertions: InMemoryTreeCache is slightly faster for single-depth insertions and significantly faster for deeper depths.
-// - Retrievals: InMemoryHashMapCache (especially with FarmHash) is faster for both single-depth and deeper retrievals.
-// - Setting Values: Performance is relatively close between the two, with minor variations.
-//
-// The choice between InMemoryTreeCache and InMemoryHashMapCache would depend on the specific use case,
-// especially the depth of the keys and the frequency of retrieval operations.
-type InMemoryHashMapCache[K CompositeKey, T Comparable, H comparable] struct {
-	values  map[H][]T
+// InMemoryHashMapCache provides an in-memory caching mechanism using hashmaps for single-value entries.
+// Unlike InMemoryHashMapMultiCache, it stores only one value per key.
+// This structure translates composite keys into a hash value using a user-provided hashing function.
+// Supports optional TTL for entries and ensures concurrency-safe operations using a mutex.
+type InMemoryHashMapCache[K CompositeKey, T any, H comparable] struct {
+	values  map[H]T
 	changes []K
 
 	lastUpdatedKeys map[string]time.Time
@@ -343,9 +66,9 @@ type InMemoryHashMapCache[K CompositeKey, T Comparable, H comparable] struct {
 // NewInMemoryHashMapCache creates a new instance of the InMemoryHashMapCache.
 // It takes a hashing function to translate the composite keys to a desired hash type,
 // and an optional time-to-live duration for the cache entries.
-func NewInMemoryHashMapCache[K CompositeKey, T Comparable, H comparable](toHash func(keys []int64) H, ttl uopt.Opt[time.Duration]) *InMemoryHashMapCache[K, T, H] {
+func NewInMemoryHashMapCache[K CompositeKey, T any, H comparable](toHash func(keys []int64) H, ttl uopt.Opt[time.Duration]) Cache[K, T] {
 	c := &InMemoryHashMapCache[K, T, H]{
-		values:          make(map[H][]T),
+		values:          make(map[H]T),
 		changes:         make([]K, 0),
 		lastUpdatedKeys: make(map[string]time.Time),
 		toHash:          toHash,
@@ -358,11 +81,11 @@ func NewInMemoryHashMapCache[K CompositeKey, T Comparable, H comparable](toHash 
 }
 
 // NewDefaultHashMapCache creates a new instance of the InMemoryHashMapCache using SHA256 as the hashing algorithm.
-func NewDefaultHashMapCache[K CompositeKey, T Comparable](ttl uopt.Opt[time.Duration]) *InMemoryHashMapCache[K, T, uint64] {
+func NewDefaultHashMapCache[K CompositeKey, T any](ttl uopt.Opt[time.Duration]) Cache[K, T] {
 	return NewFarmHashMapCache[K, T](ttl)
 }
 
-func NewFarmHashMapCache[K CompositeKey, T Comparable](ttl uopt.Opt[time.Duration]) *InMemoryHashMapCache[K, T, uint64] {
+func NewFarmHashMapCache[K CompositeKey, T any](ttl uopt.Opt[time.Duration]) Cache[K, T] {
 	buffer := new(bytes.Buffer)
 	return NewInMemoryHashMapCache[K, T, uint64](func(keys []int64) uint64 {
 		arr := make([]byte, 0)
@@ -374,68 +97,36 @@ func NewFarmHashMapCache[K CompositeKey, T Comparable](ttl uopt.Opt[time.Duratio
 	}, ttl)
 }
 
-func NewSha256HashMapCache[K CompositeKey, T Comparable](ttl uopt.Opt[time.Duration]) *InMemoryHashMapCache[K, T, string] {
-	buffer := new(bytes.Buffer)
-	return NewInMemoryHashMapCache[K, T, string](func(keys []int64) string {
-		arr := make([]byte, 0)
-		for _, hash := range keys {
-			arr = append(arr, intToBytes(buffer, hash)...)
-		}
-
-		h := sha256.New()
-		h.Write(arr)
-
-		return string(h.Sum(nil))
-	}, ttl)
-}
-
-// Put adds the given values to the cache associated with the provided key.
-// If the key already exists, the values are updated. The insertion is thread-safe.
-func (c *InMemoryHashMapCache[K, T, H]) Put(key K, values ...T) {
-	if len(values) == 0 {
-		return
-	}
+// Set updates the cache value for the provided key. If the key already exists,
+// its previous value are removed before adding the new value. The operation is thread-safe.
+func (c *InMemoryHashMapCache[K, T, H]) Set(key K, value T) {
 	c.vMtx.Lock()
 	defer c.vMtx.Unlock()
-	c.put(key, values...)
+	c.put(key, value)
 	c.lastUpdatedKeys[key.String()] = time.Now()
 	c.lastUpdated = time.Now()
 }
 
-// Set updates the cache values for the provided key. If the key already exists,
-// its previous values are removed before adding the new values. The operation is thread-safe.
-func (c *InMemoryHashMapCache[K, T, H]) Set(key K, values ...T) {
-	c.vMtx.Lock()
-	defer c.vMtx.Unlock()
-	c.dropKey(key.Keys())
-	c.put(key, values...)
-	c.lastUpdatedKeys[key.String()] = time.Now()
-	c.lastUpdated = time.Now()
-}
-
-// PutQuietly adds values to the cache for the provided key but does so without
+// SetQuietly is an optimized method that adds value to the cache for the provided key but does so without
 // altering the change history. This operation can be used when modifications should not trigger cache change diff.
-func (c *InMemoryHashMapCache[K, T, H]) PutQuietly(key K, values ...T) {
+// This operation is much faster and can be used to optimize cache performance in case you don't want to track changes.
+func (c *InMemoryHashMapCache[K, T, H]) SetQuietly(key K, value T) {
 	c.vMtx.Lock()
 	defer c.vMtx.Unlock()
-	c.addTran(key, values...)
+	c.addTran(key, value)
 	c.lastUpdatedKeys[key.String()] = time.Now()
 	c.lastUpdated = time.Now()
 }
 
-// Get retrieves the values associated with the provided key from the cache.
+// Get retrieves the value associated with the provided key from the cache.
 // The operation is thread-safe and does not alter the change history.
-func (c *InMemoryHashMapCache[K, T, H]) Get(key K) []T {
+func (c *InMemoryHashMapCache[K, T, H]) Get(key K) (*T, bool) {
 	c.vMtx.Lock()
 	defer c.vMtx.Unlock()
 	c.changes = nil
 
-	return c.values[c.toHash(key.Keys())]
-}
-
-// Changes returns a list of keys that have experienced changes in the cache since the last reset.
-func (c *InMemoryHashMapCache[K, T, H]) Changes() []K {
-	return c.changes
+	value, ok := c.values[c.toHash(key.Keys())]
+	return &value, ok
 }
 
 // Drop completely clears the cache, removing all entries. The operation is thread-safe.
@@ -446,7 +137,7 @@ func (c *InMemoryHashMapCache[K, T, H]) Drop() {
 	c.lastUpdatedKeys = make(map[string]time.Time)
 }
 
-// DropKey removes the values associated with the provided key from the cache. The operation is thread-safe.
+// DropKey removes the value associated with the provided key from the cache. The operation is thread-safe.
 func (c *InMemoryHashMapCache[K, T, H]) DropKey(key K) {
 	c.vMtx.Lock()
 	defer c.vMtx.Unlock()
@@ -478,12 +169,12 @@ func (c *InMemoryHashMapCache[K, T, H]) Outdated(key uopt.Opt[K]) bool {
 }
 
 func (c *InMemoryHashMapCache[K, T, H]) dropAll() {
-	c.values = make(map[H][]T)
+	c.values = make(map[H]T)
 	c.changes = nil
 }
 
-func (c *InMemoryHashMapCache[K, T, H]) put(key K, values ...T) {
-	c.addTran(key, values...)
+func (c *InMemoryHashMapCache[K, T, H]) put(key K, value T) {
+	c.addTran(key, value)
 	changes := len(c.changes) == 0
 	found := false
 	for _, diff := range c.changes {
@@ -501,39 +192,14 @@ func (c *InMemoryHashMapCache[K, T, H]) put(key K, values ...T) {
 	}
 }
 
-func (c *InMemoryHashMapCache[K, T, H]) addTran(key K, values ...T) {
+func (c *InMemoryHashMapCache[K, T, H]) addTran(key K, value T) {
 	keys := key.Keys()
-	if len(values) == 0 {
-		return
-	}
 
 	for i := 0; i < len(keys); i++ {
-		hash := c.toHash(keys[:i+1])
-		for _, value := range values {
-			if existing, found := c.values[hash]; found {
-				if ind, entry := uarray.ContainsPredicate[T](existing, func(v *T) bool {
-					return (*v).Equals(value)
-				}); entry == nil {
-					// Collision detected
-					c.values[hash] = append(existing, value)
-				} else {
-					// Else replace, this value is already hashed
-					c.values[hash][ind] = value
-				}
-			} else {
-				c.values[hash] = []T{value}
-			}
-		}
+		c.values[c.toHash(keys[:i+1])] = value
 	}
 }
 
 func (c *InMemoryHashMapCache[K, T, H]) dropKey(keys []int64) {
 	delete(c.values, c.toHash(keys))
-}
-
-func intToBytes(buffer *bytes.Buffer, num int64) []byte {
-	buffer.Reset()
-	_ = binary.Write(buffer, binary.LittleEndian, num)
-
-	return buffer.Bytes()
 }

--- a/ucache/ucache_bench_test.go
+++ b/ucache/ucache_bench_test.go
@@ -1,501 +1,79 @@
 /*
- * @Author: kordax, 10/5/23, 6:29 PM
+ * @kordax (Dmitry Morozov)
+ * dmorozov@valoru-software.com
+ * Copyright (c) 2024.
  */
 
-package ucache
+package ucache_test
 
 import (
-	"runtime"
+	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/kordax/basic-utils/ucache"
 	"github.com/kordax/basic-utils/uopt"
 )
 
-const (
-	numItems = 1000
-	stdDepth = 3
-)
-
-// prepareCacheIntKey populates the cache with IntKey items.
-func prepareCacheIntKey(c Cache[IntCompositeKey, Comparable], num int64) []IntCompositeKey {
-	keys := make([]IntCompositeKey, num)
-	for i := int64(0); i < num; i++ {
-		key := NewIntCompositeKey(i)
-		keys[i] = key
-		c.Put(key, NewInt64Value(i))
-	}
-
-	return keys
-}
-
-// prepareCacheIntKey populates the cache with IntKey items.
-func prepareCacheIntKeyWithDepth(c Cache[IntCompositeKey, Comparable], num, maxDepth int64) []IntCompositeKey {
-	keys := make([]IntCompositeKey, num)
-	for i := int64(0); i < num; i++ {
-		var hashes []int64
-		for h := int64(0); h < maxDepth; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
-		c.Put(key, NewInt64Value(i))
-	}
-
-	return keys
-}
-
-func BenchmarkSha256HashMapCachePutIntKeySingle(b *testing.B) {
-	c := NewSha256HashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := make([]IntCompositeKey, int64(b.N))
-	for i := int64(0); i < int64(b.N); i++ {
-		var hashes []int64
-		for h := int64(0); h < stdDepth; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
+func BenchmarkInMemoryHashMapCachePut(b *testing.B) {
+	cache := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
+	keys := make([]SimpleCompositeKey[ucache.StringKey], b.N)
+	for i := 0; i < b.N; i++ {
+		keys[i] = NewSimpleCompositeKey[ucache.StringKey](ucache.StringKey(fmt.Sprintf("key%d", i)))
 	}
 	b.ResetTimer()
 
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Put(keys[i], NewInt64Value(i))
+	for i := 0; i < b.N; i++ {
+		cache.Set(keys[i], i)
 	}
 }
 
-func BenchmarkSha256HashMapCachePutIntKeySingleDepth100(b *testing.B) {
-	c := NewSha256HashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := make([]IntCompositeKey, b.N)
-	for i := int64(0); i < int64(b.N); i++ {
-		var hashes []int64
-		for h := int64(0); h < 100; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
-	}
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Put(keys[i], NewInt64Value(i))
-	}
-}
-
-func BenchmarkSha256HashMapCachePutIntKeyConcurrent(b *testing.B) {
-	c := NewSha256HashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := make([]IntCompositeKey, b.N)
-	for i := int64(0); i < int64(b.N); i++ {
-		var hashes []int64
-		for h := int64(0); h < stdDepth; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
+func BenchmarkInMemoryHashMapCachePutConcurrent(b *testing.B) {
+	cache := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
+	keys := make([]SimpleCompositeKey[ucache.StringKey], b.N)
+	for i := 0; i < b.N; i++ {
+		keys[i] = NewSimpleCompositeKey[ucache.StringKey](ucache.StringKey(fmt.Sprintf("key%d", i)))
 	}
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			c.Put(keys[int64(b.N-1)], NewInt64Value(int64(b.N)))
+			key := keys[rand.Intn(b.N)]
+			cache.Set(key, rand.Int())
 		}
 	})
 }
 
-func BenchmarkSha256HashMapCachePutIntKeyConcurrentDepth100(b *testing.B) {
-	c := NewSha256HashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := make([]IntCompositeKey, b.N+1)
-	for i := int64(0); i < int64(b.N); i++ {
-		var hashes []int64
-		for h := int64(0); h < 100; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
+func BenchmarkInMemoryHashMapCacheGet(b *testing.B) {
+	numItems := 10000
+	cache := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
+	keys := make([]SimpleCompositeKey[ucache.StringKey], numItems)
+	for i := 0; i < numItems; i++ {
+		keys[i] = NewSimpleCompositeKey[ucache.StringKey](ucache.StringKey(fmt.Sprintf("key%d", i)))
+		cache.Set(keys[i], i)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		cache.Get(keys[i%numItems])
+	}
+}
+
+func BenchmarkInMemoryHashMapCacheGetConcurrent(b *testing.B) {
+	numItems := 10000
+	cache := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
+	keys := make([]SimpleCompositeKey[ucache.StringKey], numItems)
+	for i := 0; i < numItems; i++ {
+		keys[i] = NewSimpleCompositeKey[ucache.StringKey](ucache.StringKey(fmt.Sprintf("key%d", i)))
+		cache.Set(keys[i], i)
 	}
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			c.Put(keys[int64(b.N-1)], NewInt64Value(int64(b.N)))
+			key := keys[rand.Intn(numItems)]
+			cache.Get(key)
 		}
 	})
-}
-
-func BenchmarkSha256HashMapCacheGetIntKeySingle(b *testing.B) {
-	c := NewSha256HashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, numItems)
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Get(keys[i%numItems])
-	}
-}
-
-func BenchmarkSha256HashMapCacheGetIntKeySingleDeepDepth100(b *testing.B) {
-	c := NewSha256HashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKeyWithDepth(c, numItems, 100)
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Get(keys[i%numItems])
-	}
-}
-
-func BenchmarkSha256HashMapCacheGetIntKeyConcurrent(b *testing.B) {
-	c := NewSha256HashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, numItems)
-	b.ResetTimer()
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			c.Get(keys[int64(b.N)%numItems])
-		}
-	})
-}
-
-func BenchmarkSha256HashMapCacheSetIntKeySingle(b *testing.B) {
-	c := NewSha256HashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, numItems)
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Set(keys[i%numItems], NewInt64Value(i))
-	}
-}
-
-func BenchmarkSha256HashMapCacheSetIntKeyConcurrent(b *testing.B) {
-	c := NewSha256HashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, numItems)
-	b.ResetTimer()
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			c.Set(keys[int64(b.N)%numItems], NewInt64Value(int64(b.N)))
-		}
-	})
-}
-
-func BenchmarkSha256HashMapCacheGetIntKeySingle10xItems(b *testing.B) {
-	num := int64(numItems * 10)
-	c := NewSha256HashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, num)
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Get(keys[i%num])
-	}
-}
-
-func BenchmarkFarmHashMapCachePutIntKeySingle(b *testing.B) {
-	c := NewFarmHashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := make([]IntCompositeKey, int64(b.N))
-	for i := int64(0); i < int64(b.N); i++ {
-		var hashes []int64
-		for h := int64(0); h < stdDepth; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
-	}
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Put(keys[i], NewInt64Value(i))
-	}
-}
-
-func BenchmarkFarmHashMapCachePutIntKeySingleDepth100(b *testing.B) {
-	c := NewFarmHashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := make([]IntCompositeKey, b.N)
-	for i := int64(0); i < int64(b.N); i++ {
-		var hashes []int64
-		for h := int64(0); h < 100; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
-	}
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Put(keys[i], NewInt64Value(i))
-	}
-}
-
-func BenchmarkFarmHashMapCachePutIntKeyConcurrent(b *testing.B) {
-	c := NewFarmHashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := make([]IntCompositeKey, b.N)
-	for i := int64(0); i < int64(b.N); i++ {
-		var hashes []int64
-		for h := int64(0); h < stdDepth; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
-	}
-	b.ResetTimer()
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			c.Put(keys[int64(b.N-1)], NewInt64Value(int64(b.N)))
-		}
-	})
-}
-
-func BenchmarkFarmHashMapCachePutIntKeyConcurrentDepth100(b *testing.B) {
-	c := NewFarmHashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := make([]IntCompositeKey, b.N+1)
-	for i := int64(0); i < int64(b.N); i++ {
-		var hashes []int64
-		for h := int64(0); h < 100; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
-	}
-	b.ResetTimer()
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			c.Put(keys[int64(b.N-1)], NewInt64Value(int64(b.N)))
-		}
-	})
-}
-
-func BenchmarkFarmHashMapCacheGetIntKeySingle(b *testing.B) {
-	c := NewFarmHashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, numItems)
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Get(keys[i%numItems])
-	}
-}
-
-func BenchmarkFarmHashMapCacheGetIntKeySingleDeepDepth100(b *testing.B) {
-	c := NewFarmHashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKeyWithDepth(c, numItems, 100)
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Get(keys[i%numItems])
-	}
-}
-
-func BenchmarkFarmHashMapCacheGetIntKeyConcurrent(b *testing.B) {
-	c := NewFarmHashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, numItems)
-	b.ResetTimer()
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			c.Get(keys[int64(b.N)%numItems])
-		}
-	})
-}
-
-func BenchmarkFarmHashMapCacheSetIntKeySingle(b *testing.B) {
-	c := NewFarmHashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, numItems)
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Set(keys[i%numItems], NewInt64Value(i))
-	}
-}
-
-func BenchmarkFarmHashMapCacheSetIntKeyConcurrent(b *testing.B) {
-	c := NewFarmHashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, numItems)
-	b.ResetTimer()
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			c.Set(keys[int64(b.N)%numItems], NewInt64Value(int64(b.N)))
-		}
-	})
-}
-
-func BenchmarkFarmHashMapCacheGetIntKeySingle10xItems(b *testing.B) {
-	num := int64(numItems * 10)
-	c := NewFarmHashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, num)
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Get(keys[i%num])
-	}
-}
-
-func BenchmarkTreeCachePutIntKeySingle(b *testing.B) {
-	c := NewInMemoryTreeCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := make([]IntCompositeKey, int64(b.N))
-	for i := int64(0); i < int64(b.N); i++ {
-		var hashes []int64
-		for h := int64(0); h < stdDepth; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
-	}
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Put(keys[i], NewInt64Value(i))
-	}
-}
-
-func BenchmarkTreeCachePutIntKeySingleDepth100(b *testing.B) {
-	c := NewInMemoryTreeCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := make([]IntCompositeKey, b.N)
-	for i := int64(0); i < int64(b.N); i++ {
-		var hashes []int64
-		for h := int64(0); h < 100; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
-	}
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Put(keys[i], NewInt64Value(i))
-	}
-}
-
-func BenchmarkTreeCachePutIntKeyConcurrent(b *testing.B) {
-	c := NewInMemoryTreeCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := make([]IntCompositeKey, b.N)
-	for i := int64(0); i < int64(b.N); i++ {
-		var hashes []int64
-		for h := int64(0); h < stdDepth; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
-	}
-	b.ResetTimer()
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			c.Put(keys[int64(b.N-1)], NewInt64Value(int64(b.N)))
-		}
-	})
-}
-
-func BenchmarkTreeCachePutIntKeyConcurrentDepth100(b *testing.B) {
-	c := NewInMemoryTreeCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := make([]IntCompositeKey, b.N+1)
-	for i := int64(0); i < int64(b.N); i++ {
-		var hashes []int64
-		for h := int64(0); h < 100; h++ {
-			hashes = append(hashes, h)
-		}
-		key := NewIntCompositeKey(hashes...)
-		keys[i] = key
-	}
-	b.ResetTimer()
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			c.Put(keys[int64(b.N-1)], NewInt64Value(int64(b.N)))
-		}
-	})
-}
-
-func BenchmarkTreeCacheGetIntKeySingle(b *testing.B) {
-	c := NewInMemoryTreeCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, numItems)
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Get(keys[i%numItems])
-	}
-}
-
-func BenchmarkTreeCacheGetIntKeySingleDeepDepth100(b *testing.B) {
-	c := NewInMemoryTreeCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKeyWithDepth(c, numItems, 100)
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Get(keys[i%numItems])
-	}
-}
-
-func BenchmarkTreeCacheGetIntKeyConcurrent(b *testing.B) {
-	c := NewInMemoryTreeCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, numItems)
-	b.ResetTimer()
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			c.Get(keys[int64(b.N)%numItems])
-		}
-	})
-}
-
-func BenchmarkTreeCacheSetIntKeySingle(b *testing.B) {
-	c := NewInMemoryTreeCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, numItems)
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Set(keys[i%numItems], NewInt64Value(i))
-	}
-}
-
-func BenchmarkTreeCacheSetIntKeyConcurrent(b *testing.B) {
-	c := NewInMemoryTreeCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, numItems)
-	b.ResetTimer()
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			c.Set(keys[int64(b.N)%numItems], NewInt64Value(int64(b.N)))
-		}
-	})
-}
-
-func BenchmarkTreeCacheGetIntKeySingle10xItems(b *testing.B) {
-	num := int64(numItems * 10)
-	c := NewInMemoryTreeCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	keys := prepareCacheIntKey(c, num)
-	b.ResetTimer()
-
-	for i := int64(0); i < int64(b.N); i++ {
-		c.Get(keys[i%num])
-	}
-}
-
-func BenchmarkMemoryFarmHashMapCache(b *testing.B) {
-	c := NewFarmHashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	benchmarkMemoryUsage(b, c)
-}
-
-func BenchmarkMemorySha256HashMapCache(b *testing.B) {
-	c := NewSha256HashMapCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	benchmarkMemoryUsage(b, c)
-}
-
-func BenchmarkMemoryTreeCache(b *testing.B) {
-	c := NewInMemoryTreeCache[IntCompositeKey, Comparable](uopt.Null[time.Duration]())
-	benchmarkMemoryUsage(b, c)
-}
-
-func benchmarkMemoryUsage(b *testing.B, c Cache[IntCompositeKey, Comparable]) {
-	var m runtime.MemStats
-
-	for i := int64(0); i < numItems; i++ {
-		key := NewIntCompositeKey(i)
-		c.Put(key, NewInt64Value(i))
-	}
-
-	runtime.ReadMemStats(&m)
-	b.Logf("Memory Alloc = %v KB", bToKb(m.Alloc))
-}
-
-// Helper function to convert bytes to KB.
-func bToKb(b uint64) uint64 {
-	return b / 1024
 }


### PR DESCRIPTION
# Changelog

## [Unreleased]

### Added
- Implemented a new `Cache` interface for single-value cache operations:
  - `Set(key K, value T)` - Sets a new value to the key.
  - `Get(key K) (*T, bool)` - Retrieves the value associated with the provided key.
  - `Drop()` - Completely clears the cache.
  - `DropKey(key K)` - Removes the value associated with the provided key.
  - `Outdated(key uopt.Opt[K]) bool` - Checks if the provided key or the entire cache is outdated based on the TTL.
  - `PutQuietly(key K, value T)` - Adds a value to the cache for the provided key without altering the change history.

- Added `InMemoryHashMapCache` struct as an implementation of the new `Cache` interface:
  - Provides an in-memory caching mechanism using hashmaps for single-value entries.
  - Supports optional TTL for entries and ensures concurrency-safe operations using a mutex.

### Changed
- Renamed the existing `Cache` interface to `MultiCache` to reflect its multi-value cache operations:
  - `Put(key K, values ...T)` - Adds new values to the key.
  - `Set(key K, values ...T)` - Overwrites key values.
  - `Get(key K) []T` - Retrieves the values associated with the key.
  - `Drop()` - Completely clears the cache.
  - `DropKey(key K)` - Removes the values associated with the key.
  - `Outdated(key uopt.Opt[K]) bool` - Checks if the provided key or the entire cache is outdated based on the TTL.
  - `PutQuietly(key K, values ...T)` - Adds the values but updates cache state/doesn't add any changes to the cache.

- Updated `InMemoryHashMapMultiCache` struct to align with the new `MultiCache` interface:
  - Provides an in-memory caching mechanism using hashmaps for multi-value entries.
  - Uses user-provided hashing functions to translate composite keys.
  - Ensures concurrency-safe operations using a mutex.
  - Additional logic to manage arrays of values and handle potential collisions or duplicates.

### Removed
- The old `Cache` interface has been renamed, as it has been replaced by the new `MultiCache` interface to better reflect its purpose.

### Performance
- `InMemoryHashMapCache` provides efficient single-value cache operations.
- `InMemoryHashMapMultiCache` continues to support multi-value cache operations with optimized performance for both shallow and deep key depths.
