### PR TITLE
Feature/v1.16.0

### DIFF
--- a/ucache/composite.go
+++ b/ucache/composite.go
@@ -1,0 +1,167 @@
+/*
+* @kordax (Dmitry Morozov)
+* dmorozov@valoru-software.com
+* Copyright (c) 2024.
+ */
+
+package ucache
+
+//import (
+//	"bytes"
+//	"sync"
+//	"time"
+//
+//	"github.com/dgryski/go-farm"
+//	"github.com/kordax/basic-utils/uopt"
+//)
+//
+//// The CompositeCache is the same as Cache, but allows CompositeKeys
+//type CompositeCache[K CompositeKey, T any] interface {
+//	Cache[K, T]
+//}
+//
+//// InMemoryHashMapCompositeCache composite version of InMemoryHashMapCompositeCache
+//type InMemoryHashMapCompositeCache[K Unique, T any, H comparable] struct {
+//	values  map[H]T
+//	changes []K
+//
+//	lastUpdatedKeys map[int64]time.Time
+//	lastUpdated     time.Time
+//	ttl             *time.Duration
+//
+//	toHash func(key int64) H
+//	vMtx   sync.Mutex
+//}
+//
+//// NewInMemoryHashMapCompositeCache creates a new instance of the InMemoryHashMapCompositeCache.
+//func NewInMemoryHashMapCompositeCache[K Unique, T any, H comparable](toHash func(key int64) H, ttl uopt.Opt[time.Duration]) Cache[K, T] {
+//	c := &InMemoryHashMapCompositeCache[K, T, H]{
+//		values:          make(map[H]T),
+//		changes:         make([]K, 0),
+//		lastUpdatedKeys: make(map[int64]time.Time),
+//		toHash:          toHash,
+//	}
+//	ttl.IfPresent(func(t time.Duration) {
+//		c.ttl = &t
+//	})
+//
+//	return c
+//}
+//
+//// NewDefaultHashMapCache creates a new instance of the InMemoryHashMapCache using SHA256 as the hashing algorithm.
+//func NewDefaultHashMapCache[K Unique, T any](ttl uopt.Opt[time.Duration]) Cache[K, T] {
+//	return NewFarmHashMapCache[K, T](ttl)
+//}
+//
+//func NewFarmHashMapCache[K Unique, T any](ttl uopt.Opt[time.Duration]) Cache[K, T] {
+//	return NewInMemoryHashMapCache[K, T, uint64](func(key int64) uint64 {
+//		buffer := new(bytes.Buffer)
+//		return farm.Hash64(intToBytes(buffer, key))
+//	}, ttl)
+//}
+//
+//// Set updates the cache value for the provided key. If the key already exists,
+//// its previous value are removed before adding the new value. The operation is thread-safe.
+//func (c *InMemoryHashMapCompositeCache[K, T, H]) Set(key K, value T) {
+//	c.vMtx.Lock()
+//	defer c.vMtx.Unlock()
+//	c.put(key, value)
+//	c.lastUpdatedKeys[key.Key()] = time.Now()
+//	c.lastUpdated = time.Now()
+//}
+//
+//// SetQuietly is an optimized method that adds value to the cache for the provided key but does so without
+//// altering the change history. This operation can be used when modifications should not trigger cache change diff.
+//// This operation is much faster and can be used to optimize cache performance in case you don't want to track changes.
+//func (c *InMemoryHashMapCompositeCache[K, T, H]) SetQuietly(key K, value T) {
+//	c.vMtx.Lock()
+//	defer c.vMtx.Unlock()
+//	c.addTran(key, value)
+//	c.lastUpdatedKeys[key.Key()] = time.Now()
+//	c.lastUpdated = time.Now()
+//}
+//
+//// Get retrieves the value associated with the provided key from the cache.
+//// The operation is thread-safe and does not alter the change history.
+//func (c *InMemoryHashMapCompositeCache[K, T, H]) Get(key K) (*T, bool) {
+//	c.vMtx.Lock()
+//	defer c.vMtx.Unlock()
+//	c.changes = nil
+//
+//	value, ok := c.values[c.toHash(key.Key())]
+//	if !ok {
+//		return nil, false
+//	}
+//	return &value, ok
+//}
+//
+//// Drop completely clears the cache, removing all entries. The operation is thread-safe.
+//func (c *InMemoryHashMapCompositeCache[K, T, H]) Drop() {
+//	c.vMtx.Lock()
+//	defer c.vMtx.Unlock()
+//	c.dropAll()
+//	c.lastUpdatedKeys = make(map[int64]time.Time)
+//}
+//
+//// DropKey removes the value associated with the provided key from the cache. The operation is thread-safe.
+//func (c *InMemoryHashMapCompositeCache[K, T, H]) DropKey(key K) {
+//	c.vMtx.Lock()
+//	defer c.vMtx.Unlock()
+//	c.dropKey(key.Key())
+//	c.lastUpdatedKeys[key.Key()] = time.Now()
+//	c.lastUpdated = time.Now()
+//}
+//
+//// Outdated checks if the provided key or the entire cache (if no key is provided)
+//// is outdated based on the set TTL. Returns true if outdated, false otherwise.
+//func (c *InMemoryHashMapCompositeCache[K, T, H]) Outdated(key uopt.Opt[K]) bool {
+//	c.vMtx.Lock()
+//	defer c.vMtx.Unlock()
+//
+//	if c.ttl == nil {
+//		return false
+//	} else {
+//		if key.Present() {
+//			k := key.Get()
+//			if lu, ok := c.lastUpdatedKeys[(*k).Key()]; ok {
+//				return time.Since(lu) > *c.ttl
+//			} else {
+//				return true
+//			}
+//		} else {
+//			return time.Since(c.lastUpdated) > *c.ttl
+//		}
+//	}
+//}
+//
+//func (c *InMemoryHashMapCompositeCache[K, T, H]) dropAll() {
+//	c.values = make(map[H]T)
+//	c.changes = nil
+//}
+//
+//func (c *InMemoryHashMapCompositeCache[K, T, H]) put(key K, value T) {
+//	c.addTran(key, value)
+//	changes := len(c.changes) == 0
+//	found := false
+//	for _, diff := range c.changes {
+//		if diff.Key() == key.Key() {
+//			if !diff.Equals(key) {
+//				changes = true
+//				break
+//			}
+//			found = true
+//			continue
+//		}
+//	}
+//	if changes || !found {
+//		c.changes = append(c.changes, key)
+//	}
+//}
+//
+//func (c *InMemoryHashMapCompositeCache[K, T, H]) addTran(key K, value T) {
+//	c.values[c.toHash(key.Key())] = value
+//}
+//
+//func (c *InMemoryHashMapCompositeCache[K, T, H]) dropKey(key int64) {
+//	delete(c.values, c.toHash(key))
+//}

--- a/ucache/multicache_test.go
+++ b/ucache/multicache_test.go
@@ -45,7 +45,7 @@ func (s SimpleKey) String() string {
 	return strconv.Itoa(int(s))
 }
 
-type SimpleCompositeKey[T ucache.Hashed] struct {
+type SimpleCompositeKey[T ucache.Unique] struct {
 	keys []T
 }
 
@@ -67,10 +67,10 @@ func (s SimpleCompositeKey[T]) Equals(other ucache.Comparable) bool {
 	}
 }
 
-func (s SimpleCompositeKey[T]) Keys() []int64 {
-	result := make([]int64, len(s.keys))
+func (s SimpleCompositeKey[T]) Keys() []ucache.Unique {
+	result := make([]ucache.Unique, len(s.keys))
 	for i, key := range s.keys {
-		result[i] = key.Key()
+		result[i] = ucache.UIntKey(key.Key())
 	}
 
 	return result
@@ -79,13 +79,13 @@ func (s SimpleCompositeKey[T]) Keys() []int64 {
 func (s SimpleCompositeKey[T]) String() string {
 	rep := make([]string, len(s.keys))
 	for i, key := range s.keys {
-		rep[i] = key.String()
+		rep[i] = strconv.FormatInt(key.Key(), 10)
 	}
 
 	return strings.Join(rep, ", ")
 }
 
-func NewSimpleCompositeKey[T ucache.Hashed](keys ...T) SimpleCompositeKey[T] {
+func NewSimpleCompositeKey[T ucache.Unique](keys ...T) SimpleCompositeKey[T] {
 	return SimpleCompositeKey[T]{keys: keys}
 }
 
@@ -363,8 +363,12 @@ type CollisionTestKey struct {
 }
 
 // Implement the CompositeKey interface for TestKey
-func (k CollisionTestKey) Keys() []int64 {
-	return k.hash
+func (k CollisionTestKey) Keys() []ucache.Unique {
+	result := make([]ucache.Unique, len(k.hash))
+	for i, h := range k.hash {
+		result[i] = ucache.IntKey(h)
+	}
+	return result
 }
 
 func (k CollisionTestKey) String() string {

--- a/ucache/multicache_test.go
+++ b/ucache/multicache_test.go
@@ -123,10 +123,7 @@ func TestHashMapMultiCache(t *testing.T) {
 	}
 
 	result = c.Get(partialComplexKey)
-	assert.NotEmpty(t, result)
-	for i := 0; i < 10; i++ {
-		assert.Contains(t, result, DummyComparable{i})
-	}
+	assert.Empty(t, result)
 }
 
 func TestHashMapMultiCache_CompositeKey(t *testing.T) {
@@ -163,7 +160,7 @@ func TestHashMapMultiCache_DropKey(t *testing.T) {
 	catRes := c.Get(categoryKey)
 	res := c.Get(key)
 	res2 := c.Get(key2)
-	assert.Len(t, catRes, 2)
+	assert.Len(t, catRes, 1)
 	assert.Len(t, res, 1)
 	assert.Len(t, res2, 1)
 
@@ -171,7 +168,7 @@ func TestHashMapMultiCache_DropKey(t *testing.T) {
 	catRes = c.Get(categoryKey)
 	res = c.Get(key)
 	res2 = c.Get(key2)
-	assert.Len(t, catRes, 2)
+	assert.Len(t, catRes, 1)
 	assert.Len(t, res, 0)
 	assert.Len(t, res2, 1)
 }
@@ -191,11 +188,11 @@ func TestHashMapMultiCache_PutQuietly(t *testing.T) {
 
 	c.PutQuietly(key, val2)
 	results = c.Get(key)
-	assert.Len(t, results, 2)
+	assert.Len(t, results, 1)
 
 	c.PutQuietly(key, val)
 	results = c.Get(key)
-	assert.Len(t, results, 2)
+	assert.Len(t, results, 1)
 }
 
 func TestTreeMultiCache(t *testing.T) {

--- a/ucache/types_test.go
+++ b/ucache/types_test.go
@@ -81,7 +81,7 @@ func TestUIntKey_Equals(t *testing.T) {
 func TestUIntKey_Key(t *testing.T) {
 	value := ucache.UIntKey(123)
 	key := value.Key()
-	assert.Equal(t, 123, key)
+	assert.EqualValues(t, 123, key)
 
 	value2 := ucache.UIntKey(456)
 	key2 := value2.Key()
@@ -92,8 +92,8 @@ func TestIntCompositeKey_Keys(t *testing.T) {
 	value := ucache.NewIntCompositeKey(123, 456)
 	keys := value.Keys()
 	assert.Len(t, keys, 2)
-	assert.Contains(t, keys, int64(123))
-	assert.Contains(t, keys, int64(456))
+	assert.Contains(t, keys, ucache.IntKey(123))
+	assert.Contains(t, keys, ucache.IntKey(456))
 
 	value2 := ucache.NewIntCompositeKey(789)
 	keys2 := value2.Keys()
@@ -146,14 +146,15 @@ func TestUIntCompositeKey_Keys_String(t *testing.T) {
 
 func TestIntCompositeKey_Keys_String(t *testing.T) {
 	key := ucache.NewIntCompositeKey(1, 2, 3)
-	assert.EqualValues(t, []int64{1, 2, 3}, key.Keys())
+	expectedUniqueKeys := []ucache.Unique{ucache.IntKey(1), ucache.IntKey(2), ucache.IntKey(3)}
+	assert.EqualValues(t, expectedUniqueKeys, key.Keys())
 	assert.Equal(t, "1, 2, 3", key.String())
 }
 
 func TestStrCompositeKey_Keys_String(t *testing.T) {
 	key := ucache.NewStrCompositeKey("a", "b", "c")
-	expectedKeys := []int64{97, 98, 99} // ASCII values of 'a', 'b', 'c'
-	assert.EqualValues(t, expectedKeys, key.Keys())
+	expectedUniqueKeys := []ucache.Unique{ucache.IntKey(97), ucache.IntKey(98), ucache.IntKey(99)} // ASCII values of 'a', 'b', 'c'
+	assert.EqualValues(t, expectedUniqueKeys, key.Keys())
 	assert.Equal(t, "a, b, c", key.String())
 }
 

--- a/ucache/ucache.go
+++ b/ucache/ucache.go
@@ -12,14 +12,13 @@ import (
 	"time"
 
 	"github.com/dgryski/go-farm"
-	"github.com/kordax/basic-utils/uarray"
 	"github.com/kordax/basic-utils/uopt"
 )
 
 // The Cache interface defines a set of methods for a generic cache implementation.
 // This interface supports setting, getting, and managing cache entries with composite keys.
-// Unlike MultiCache, it is designed to handle only one value per key.
-type Cache[K CompositeKey, T any] interface {
+// Unlike MultiCache, it is designed to handle only one value per key and does not support hierarchical composite keys.
+type Cache[K Hashed, T any] interface {
 	// Set updates the cache value for the provided key. If the key already exists,
 	// its previous value is removed before adding the new value. This method should be thread-safe.
 	Set(key K, value T)
@@ -51,7 +50,7 @@ type Cache[K CompositeKey, T any] interface {
 // Unlike InMemoryHashMapMultiCache, it stores only one value per key.
 // This structure translates composite keys into a hash value using a user-provided hashing function.
 // Supports optional TTL for entries and ensures concurrency-safe operations using a mutex.
-type InMemoryHashMapCache[K CompositeKey, T any, H comparable] struct {
+type InMemoryHashMapCache[K Hashed, T any, H comparable] struct {
 	values  map[H]T
 	changes []K
 
@@ -59,14 +58,14 @@ type InMemoryHashMapCache[K CompositeKey, T any, H comparable] struct {
 	lastUpdated     time.Time
 	ttl             *time.Duration
 
-	toHash func(keys []int64) H
+	toHash func(key int64) H
 	vMtx   sync.Mutex
 }
 
 // NewInMemoryHashMapCache creates a new instance of the InMemoryHashMapCache.
 // It takes a hashing function to translate the composite keys to a desired hash type,
 // and an optional time-to-live duration for the cache entries.
-func NewInMemoryHashMapCache[K CompositeKey, T any, H comparable](toHash func(keys []int64) H, ttl uopt.Opt[time.Duration]) Cache[K, T] {
+func NewInMemoryHashMapCache[K Hashed, T any, H comparable](toHash func(key int64) H, ttl uopt.Opt[time.Duration]) Cache[K, T] {
 	c := &InMemoryHashMapCache[K, T, H]{
 		values:          make(map[H]T),
 		changes:         make([]K, 0),
@@ -81,19 +80,14 @@ func NewInMemoryHashMapCache[K CompositeKey, T any, H comparable](toHash func(ke
 }
 
 // NewDefaultHashMapCache creates a new instance of the InMemoryHashMapCache using SHA256 as the hashing algorithm.
-func NewDefaultHashMapCache[K CompositeKey, T any](ttl uopt.Opt[time.Duration]) Cache[K, T] {
+func NewDefaultHashMapCache[K Hashed, T any](ttl uopt.Opt[time.Duration]) Cache[K, T] {
 	return NewFarmHashMapCache[K, T](ttl)
 }
 
-func NewFarmHashMapCache[K CompositeKey, T any](ttl uopt.Opt[time.Duration]) Cache[K, T] {
-	buffer := new(bytes.Buffer)
-	return NewInMemoryHashMapCache[K, T, uint64](func(keys []int64) uint64 {
-		arr := make([]byte, 0)
-		for _, hash := range keys {
-			arr = append(arr, intToBytes(buffer, hash)...)
-		}
-
-		return farm.Hash64(arr)
+func NewFarmHashMapCache[K Hashed, T any](ttl uopt.Opt[time.Duration]) Cache[K, T] {
+	return NewInMemoryHashMapCache[K, T, uint64](func(key int64) uint64 {
+		buffer := new(bytes.Buffer)
+		return farm.Hash64(intToBytes(buffer, key))
 	}, ttl)
 }
 
@@ -125,7 +119,10 @@ func (c *InMemoryHashMapCache[K, T, H]) Get(key K) (*T, bool) {
 	defer c.vMtx.Unlock()
 	c.changes = nil
 
-	value, ok := c.values[c.toHash(key.Keys())]
+	value, ok := c.values[c.toHash(key.Key())]
+	if !ok {
+		return nil, false
+	}
 	return &value, ok
 }
 
@@ -141,7 +138,7 @@ func (c *InMemoryHashMapCache[K, T, H]) Drop() {
 func (c *InMemoryHashMapCache[K, T, H]) DropKey(key K) {
 	c.vMtx.Lock()
 	defer c.vMtx.Unlock()
-	c.dropKey(key.Keys())
+	c.dropKey(key.Key())
 	c.lastUpdatedKeys[key.String()] = time.Now()
 	c.lastUpdated = time.Now()
 }
@@ -178,7 +175,7 @@ func (c *InMemoryHashMapCache[K, T, H]) put(key K, value T) {
 	changes := len(c.changes) == 0
 	found := false
 	for _, diff := range c.changes {
-		if uarray.EqualsWithOrder(diff.Keys(), key.Keys()) {
+		if diff.Key() == key.Key() {
 			if !diff.Equals(key) {
 				changes = true
 				break
@@ -193,13 +190,9 @@ func (c *InMemoryHashMapCache[K, T, H]) put(key K, value T) {
 }
 
 func (c *InMemoryHashMapCache[K, T, H]) addTran(key K, value T) {
-	keys := key.Keys()
-
-	for i := 0; i < len(keys); i++ {
-		c.values[c.toHash(keys[:i+1])] = value
-	}
+	c.values[c.toHash(key.Key())] = value
 }
 
-func (c *InMemoryHashMapCache[K, T, H]) dropKey(keys []int64) {
-	delete(c.values, c.toHash(keys))
+func (c *InMemoryHashMapCache[K, T, H]) dropKey(key int64) {
+	delete(c.values, c.toHash(key))
 }

--- a/ucache/ucache_bench_test.go
+++ b/ucache/ucache_bench_test.go
@@ -17,10 +17,10 @@ import (
 )
 
 func BenchmarkInMemoryHashMapCachePut(b *testing.B) {
-	cache := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
-	keys := make([]SimpleCompositeKey[ucache.StringKey], b.N)
+	cache := ucache.NewDefaultHashMapCache[ucache.StringKey, int](uopt.Null[time.Duration]())
+	keys := make([]ucache.StringKey, b.N)
 	for i := 0; i < b.N; i++ {
-		keys[i] = NewSimpleCompositeKey[ucache.StringKey](ucache.StringKey(fmt.Sprintf("key%d", i)))
+		keys[i] = ucache.StringKey(fmt.Sprintf("key%d", i))
 	}
 	b.ResetTimer()
 
@@ -30,10 +30,10 @@ func BenchmarkInMemoryHashMapCachePut(b *testing.B) {
 }
 
 func BenchmarkInMemoryHashMapCachePutConcurrent(b *testing.B) {
-	cache := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
-	keys := make([]SimpleCompositeKey[ucache.StringKey], b.N)
+	cache := ucache.NewDefaultHashMapCache[ucache.StringKey, int](uopt.Null[time.Duration]())
+	keys := make([]ucache.StringKey, b.N)
 	for i := 0; i < b.N; i++ {
-		keys[i] = NewSimpleCompositeKey[ucache.StringKey](ucache.StringKey(fmt.Sprintf("key%d", i)))
+		keys[i] = ucache.StringKey(fmt.Sprintf("key%d", i))
 	}
 	b.ResetTimer()
 
@@ -47,10 +47,10 @@ func BenchmarkInMemoryHashMapCachePutConcurrent(b *testing.B) {
 
 func BenchmarkInMemoryHashMapCacheGet(b *testing.B) {
 	numItems := 10000
-	cache := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
-	keys := make([]SimpleCompositeKey[ucache.StringKey], numItems)
+	cache := ucache.NewDefaultHashMapCache[ucache.StringKey, int](uopt.Null[time.Duration]())
+	keys := make([]ucache.StringKey, numItems)
 	for i := 0; i < numItems; i++ {
-		keys[i] = NewSimpleCompositeKey[ucache.StringKey](ucache.StringKey(fmt.Sprintf("key%d", i)))
+		keys[i] = ucache.StringKey(fmt.Sprintf("key%d", i))
 		cache.Set(keys[i], i)
 	}
 	b.ResetTimer()
@@ -62,10 +62,10 @@ func BenchmarkInMemoryHashMapCacheGet(b *testing.B) {
 
 func BenchmarkInMemoryHashMapCacheGetConcurrent(b *testing.B) {
 	numItems := 10000
-	cache := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
-	keys := make([]SimpleCompositeKey[ucache.StringKey], numItems)
+	cache := ucache.NewDefaultHashMapCache[ucache.StringKey, int](uopt.Null[time.Duration]())
+	keys := make([]ucache.StringKey, numItems)
 	for i := 0; i < numItems; i++ {
-		keys[i] = NewSimpleCompositeKey[ucache.StringKey](ucache.StringKey(fmt.Sprintf("key%d", i)))
+		keys[i] = ucache.StringKey(fmt.Sprintf("key%d", i))
 		cache.Set(keys[i], i)
 	}
 	b.ResetTimer()

--- a/ucache/ucache_test.go
+++ b/ucache/ucache_test.go
@@ -7,8 +7,6 @@
 package ucache_test
 
 import (
-	"math/rand"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -19,44 +17,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHashMapCache(t *testing.T) {
-	c := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
-	key := NewSimpleCompositeKey[ucache.StringKey]("atest")
-	key2 := NewSimpleCompositeKey[ucache.StringKey]("bSeCond-keyQ@!%!%#")
-	val := 326
-	c.Set(key, val)
-
-	cached, ok := c.Get(key)
-	require.True(t, ok, "value was expected to be cached")
-	assert.Equal(t, val, *cached)
-
-	for i := 0; i < 10; i++ {
-		c.Set(key, i)
-	}
-	c.Set(key2, 65535)
-
-	result, ok := c.Get(key2)
-	require.True(t, ok, "value was expected to be cached")
-	assert.Equal(t, *result, 65535)
-
-	complexKeyBase := []ucache.StringKey{"p1", "p2", "p3"}
-	partialComplexKey := NewSimpleCompositeKey[ucache.StringKey](complexKeyBase...)
-
-	for i := 0; i < 10; i++ {
-		complexKey := NewSimpleCompositeKey[ucache.StringKey](append(complexKeyBase, ucache.StringKey("number:"+strconv.Itoa(i)))...)
-		c.Set(complexKey, i)
-	}
-
-	result, ok = c.Get(partialComplexKey)
-	require.True(t, ok, "value was expected to be cached")
-	assert.NotEmpty(t, result)
-	assert.Equal(t, 9, *result)
-}
-
 func TestHashMapCache_CompositeKey(t *testing.T) {
-	c := ucache.NewDefaultHashMapCache[ucache.StrCompositeKey, int](uopt.Null[time.Duration]())
-	key := ucache.NewStrCompositeKey("category", "kp_2")
-	key2 := ucache.NewStrCompositeKey("category2", "kp_2")
+	c := ucache.NewDefaultHashMapCache[ucache.StringKey, int](uopt.Null[time.Duration]())
+	key := ucache.StringKey("category")
+	key2 := ucache.StringKey("category2")
 	val := 10
 	val2 := 236261
 
@@ -71,43 +35,9 @@ func TestHashMapCache_CompositeKey(t *testing.T) {
 	assert.EqualValues(t, val2, *result2)
 }
 
-func TestHashMapCache_DropKey(t *testing.T) {
-	c := ucache.NewDefaultHashMapCache[ucache.StrCompositeKey, int](uopt.Null[time.Duration]())
-	categoryKey := ucache.NewStrCompositeKey("category")
-	overlappingKey := ucache.NewStrCompositeKey("category", "kp_232626")
-	key2 := ucache.NewStrCompositeKey("category2", "kp_232626")
-	catVal := rand.Int()
-	val := rand.Int()
-	val2 := rand.Int()
-
-	c.Set(categoryKey, catVal)
-	c.Set(overlappingKey, val)
-	c.Set(key2, val2)
-
-	catRes, _ := c.Get(categoryKey)
-
-	res, ok := c.Get(overlappingKey)
-	require.True(t, ok, "value was expected to be cached")
-	res2, ok := c.Get(key2)
-	require.True(t, ok, "value was expected to be cached")
-	assert.Equal(t, val, *catRes)
-	assert.Equal(t, val, *res)
-	assert.Equal(t, val2, *res2)
-
-	c.DropKey(overlappingKey)
-	catRes, ok = c.Get(categoryKey)
-	require.True(t, ok, "value was expected to remain")
-	assert.Equal(t, val, *catRes)
-	_, ok = c.Get(overlappingKey)
-	require.False(t, ok, "value was expected to be cleared out of the cache")
-	res2, ok = c.Get(key2)
-	require.True(t, ok, "value was expected to remain")
-	assert.Equal(t, val2, *res2)
-}
-
 func TestHashMapCache_PutQuietly(t *testing.T) {
-	c := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
-	key := NewSimpleCompositeKey[ucache.StringKey]("kp_1", "kp_2")
+	c := ucache.NewDefaultHashMapCache[ucache.StringKey, int](uopt.Null[time.Duration]())
+	key := ucache.StringKey("kp_1")
 	val := 10
 	val2 := 15
 
@@ -132,8 +62,8 @@ func TestHashMapCache_PutQuietly(t *testing.T) {
 
 func TestHashMapCache_TTLExpiry(t *testing.T) {
 	ttl := 1 * time.Second
-	c := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Of(ttl))
-	key := NewSimpleCompositeKey[ucache.StringKey]("ttlKey")
+	c := ucache.NewDefaultHashMapCache[ucache.StringKey, int](uopt.Of(ttl))
+	key := ucache.StringKey("ttlKey")
 	val := 42
 
 	c.Set(key, val)
@@ -143,8 +73,8 @@ func TestHashMapCache_TTLExpiry(t *testing.T) {
 }
 
 func TestHashMapCache_Concurrency(t *testing.T) {
-	c := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
-	key := NewSimpleCompositeKey[ucache.StringKey]("concurrencyKey")
+	c := ucache.NewDefaultHashMapCache[ucache.StringKey, int](uopt.Null[time.Duration]())
+	key := ucache.StringKey("concurrencyKey")
 	val := 42
 
 	var wg sync.WaitGroup
@@ -161,8 +91,8 @@ func TestHashMapCache_Concurrency(t *testing.T) {
 }
 
 func TestHashMapCache_EmptyCache(t *testing.T) {
-	c := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
-	key := NewSimpleCompositeKey[ucache.StringKey]("emptyKey")
+	c := ucache.NewDefaultHashMapCache[ucache.StringKey, int](uopt.Null[time.Duration]())
+	key := ucache.StringKey("emptyKey")
 
 	_, ok := c.Get(key)
 	assert.False(t, ok, "key should not be found in an empty cache")
@@ -173,9 +103,9 @@ func TestHashMapCache_EmptyCache(t *testing.T) {
 }
 
 func TestHashMapCache_DropAll(t *testing.T) {
-	c := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
-	key := NewSimpleCompositeKey[ucache.StringKey]("key1")
-	key2 := NewSimpleCompositeKey[ucache.StringKey]("key2")
+	c := ucache.NewDefaultHashMapCache[ucache.StringKey, int](uopt.Null[time.Duration]())
+	key := ucache.StringKey("key1")
+	key2 := ucache.StringKey("key2")
 	c.Set(key, 1)
 	c.Set(key2, 2)
 
@@ -187,14 +117,110 @@ func TestHashMapCache_DropAll(t *testing.T) {
 	assert.False(t, ok2, "key2 should be dropped")
 }
 
-func TestHashMapCache_PartialKeyMatch(t *testing.T) {
-	c := ucache.NewDefaultHashMapCache[SimpleCompositeKey[ucache.StringKey], int](uopt.Null[time.Duration]())
-	fullKey := NewSimpleCompositeKey[ucache.StringKey]("part1", "part2")
-	partialKey := NewSimpleCompositeKey[ucache.StringKey]("part1")
-	val := 123
+func TestInMemoryHashMapCache(t *testing.T) {
+	cache := ucache.NewInMemoryHashMapCache[ucache.IntKey, string, uint64](func(key int64) uint64 {
+		return uint64(key)
+	}, uopt.Null[time.Duration]())
 
-	c.Set(fullKey, val)
-	result, ok := c.Get(partialKey)
-	assert.True(t, ok, "partial key should match")
-	assert.Equal(t, val, *result)
+	// Define multiple keys and values
+	key1 := ucache.IntKey(1)
+	value1 := "MyValue"
+
+	key2 := ucache.IntKey(2)
+	value2 := "AnotherValue"
+
+	key3 := ucache.IntKey(3)
+	value3 := "ThirdValue"
+
+	key4 := ucache.IntKey(4)
+	value4 := "FourthValue"
+
+	key5 := ucache.IntKey(5)
+	value5 := "FifthValue"
+
+	// Test setting and getting multiple keys
+	cache.Set(key1, value1)
+	cache.Set(key2, value2)
+	cache.Set(key3, value3)
+	cache.Set(key4, value4)
+	cache.Set(key5, value5)
+
+	// Verify all keys return correct values
+	retrievedValue, ok := cache.Get(key1)
+	require.True(t, ok, "Expected to retrieve value for key1")
+	assert.Equal(t, value1, *retrievedValue, "Retrieved value should match the set value")
+
+	retrievedValue, ok = cache.Get(key2)
+	require.True(t, ok, "Expected to retrieve value for key2")
+	assert.Equal(t, value2, *retrievedValue, "Retrieved value should match the set value")
+
+	retrievedValue, ok = cache.Get(key3)
+	require.True(t, ok, "Expected to retrieve value for key3")
+	assert.Equal(t, value3, *retrievedValue, "Retrieved value should match the set value")
+
+	retrievedValue, ok = cache.Get(key4)
+	require.True(t, ok, "Expected to retrieve value for key4")
+	assert.Equal(t, value4, *retrievedValue, "Retrieved value should match the set value")
+
+	retrievedValue, ok = cache.Get(key5)
+	require.True(t, ok, "Expected to retrieve value for key5")
+	assert.Equal(t, value5, *retrievedValue, "Retrieved value should match the set value")
+
+	// Test updating values for existing keys
+	updatedValue1 := "UpdatedMyValue"
+	cache.Set(key1, updatedValue1)
+	retrievedValue, ok = cache.Get(key1)
+	require.True(t, ok, "Expected to retrieve updated value for key1")
+	assert.Equal(t, updatedValue1, *retrievedValue, "Retrieved value should match the updated value")
+
+	// Test removing keys
+	cache.DropKey(key1)
+	retrievedValue, ok = cache.Get(key1)
+	assert.False(t, ok, "Expected key1 to be removed from cache")
+	assert.Nil(t, retrievedValue, "Retrieved value for removed key1 should be nil")
+
+	// Ensure other keys are still retrievable and correct after removing key1
+	retrievedValue, ok = cache.Get(key2)
+	require.True(t, ok, "Expected to retrieve value for key2")
+	assert.Equal(t, value2, *retrievedValue, "Retrieved value should match the set value")
+
+	retrievedValue, ok = cache.Get(key3)
+	require.True(t, ok, "Expected to retrieve value for key3")
+	assert.Equal(t, value3, *retrievedValue, "Retrieved value should match the set value")
+
+	retrievedValue, ok = cache.Get(key4)
+	require.True(t, ok, "Expected to retrieve value for key4")
+	assert.Equal(t, value4, *retrievedValue, "Retrieved value should match the set value")
+
+	retrievedValue, ok = cache.Get(key5)
+	require.True(t, ok, "Expected to retrieve value for key5")
+	assert.Equal(t, value5, *retrievedValue, "Retrieved value should match the set value")
+
+	// Test SetQuietly
+	cache.SetQuietly(key1, updatedValue1)
+	retrievedValue, ok = cache.Get(key1)
+	require.True(t, ok, "Expected to retrieve value for key1 after SetQuietly")
+	assert.Equal(t, updatedValue1, *retrievedValue, "Retrieved value should match the set value")
+
+	// Test Drop (clearing the entire cache)
+	cache.Drop()
+	retrievedValue, ok = cache.Get(key1)
+	assert.False(t, ok, "Expected key1 to be removed from cache after Drop")
+	assert.Nil(t, retrievedValue, "Retrieved value for removed key1 should be nil after Drop")
+
+	retrievedValue, ok = cache.Get(key2)
+	assert.False(t, ok, "Expected key2 to be removed from cache after Drop")
+	assert.Nil(t, retrievedValue, "Retrieved value for removed key2 should be nil after Drop")
+
+	retrievedValue, ok = cache.Get(key3)
+	assert.False(t, ok, "Expected key3 to be removed from cache after Drop")
+	assert.Nil(t, retrievedValue, "Retrieved value for removed key3 should be nil after Drop")
+
+	retrievedValue, ok = cache.Get(key4)
+	assert.False(t, ok, "Expected key4 to be removed from cache after Drop")
+	assert.Nil(t, retrievedValue, "Retrieved value for removed key4 should be nil after Drop")
+
+	retrievedValue, ok = cache.Get(key5)
+	assert.False(t, ok, "Expected key5 to be removed from cache after Drop")
+	assert.Nil(t, retrievedValue, "Retrieved value for removed key5 should be nil after Drop")
 }

--- a/ucache/ucache_test.go
+++ b/ucache/ucache_test.go
@@ -61,13 +61,13 @@ func TestHashMapCache_PutQuietly(t *testing.T) {
 }
 
 func TestHashMapCache_TTLExpiry(t *testing.T) {
-	ttl := 1 * time.Second
+	ttl := 100 * time.Millisecond
 	c := ucache.NewDefaultHashMapCache[ucache.StringKey, int](uopt.Of(ttl))
 	key := ucache.StringKey("ttlKey")
 	val := 42
 
 	c.Set(key, val)
-	time.Sleep(2 * time.Second)
+	time.Sleep(2 * ttl)
 	outdated := c.Outdated(uopt.Of(key))
 	assert.True(t, outdated, "key should be marked as outdated")
 }


### PR DESCRIPTION
ucache: refactor interfaces

1. `Hashed` is now `Unique`.
2. Composite key now depends on `Unique` as a 'key' provider.
3. Several potential leaks were fixed.
4. Improved cache performance.
5. Removed the need for the `String()` method.

- Unlike `InMemoryTreeMultiCache`, it doesn't support a hierarchy for keys, so each key is unique.
- Setting a more specific key (e.g., `[1, 2, 3, 4]`) **WILL NOT** replace the value of a broader key (e.g., `[1, 2, 3]`).
- Deleting a specific key or a parent key (e.g., `[1, 2]`) will not affect the other one.
